### PR TITLE
chore: sync private v4.4.1 (3fc3c15)

### DIFF
--- a/.cursor/commands/continue-plan.md
+++ b/.cursor/commands/continue-plan.md
@@ -12,9 +12,10 @@ Resume a plan from the last handoff. Confirm the next unit, then execute **only 
 ## Hard stops
 
 1. **Read `.cursor/HANDOFF.md` first.** No handoff → say so and suggest `/start-project`. Do not invent progress.
-2. **Summarize and wait for yes** before editing. "Ready?" / "Sound good?" is a real gate, not flavor text.
-3. **One unit per chat** (phase or one heavy to-do) unless the user explicitly ran `/run-plan`.
-4. **Do not start a competing plan.** New goal requires `/start-project`, which parks the active plan and proceeds to create a new one.
+2. **Apply workspace skin chrome.** Read `.cursor/context/config.json` for `workspaceSkin.modes.continue-plan` (fallback to "autopilot"). Use the corresponding skin's `chatHints` from `registry/skins/core/` for tone and confirmations.
+3. **Summarize and wait for yes** before editing. "Ready?" / "Sound good?" is a real gate, not flavor text.
+4. **One unit per chat** (phase or one heavy to-do) unless the user explicitly ran `/run-plan`.
+5. **Do not start a competing plan.** New goal requires `/start-project`, which parks the active plan and proceeds to create a new one.
 
 ## What to Do
 

--- a/.cursor/commands/git-prod.md
+++ b/.cursor/commands/git-prod.md
@@ -12,6 +12,6 @@ Follow the **git prod** routine to promote `origin/staging` to `origin/main` (pr
    Options: `Proceed with production deploy` / `Review changes first` / `Cancel`
    
    **Fallback:** if Ask questions tool unavailable, ask for explicit confirmation in chat.
-5. Run merge to main, push main, confirm production.
+5. Run merge to main, push main, create/push annotated vX.Y.Z tag (when absent), confirm production.
 6. Update `.cursor/HANDOFF.md` ("promoted to production") and memory-loop WRITE if it applies.
-7. In this monorepo: after prod, run the public sync per `autogit/gitupdate.md` / `pnpm git:trigger-public-sync` when applicable.
+7. In this monorepo: annotated tags trigger `publish-npm` + `sync-public` CI; `pnpm git:trigger-public-sync` fallback when needed per `autogit/gitupdate.md`.

--- a/.cursor/commands/onboard.md
+++ b/.cursor/commands/onboard.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Run the **first-session welcome** for Agent Kit: short orientation, HITL choice to create a first plan or skip, and an `onboarded` marker so this does not repeat.
+Run the **first-session welcome** for Agent Kit: short orientation, workspace skin preference, HITL choice to create a first plan or skip, and an `onboarded` marker so this does not repeat.
 
 This command does **not** write a plan file. Plan bootstrap stays in `/start-project` (Gate A + Gate B).
 
@@ -30,8 +30,9 @@ Read `.cursor/context/config.json` (create nothing yet).
 
 1. Short message: onboarding already ran for this project.
 2. Use **Ask questions** (chat fallback if tool unavailable):
-   - Options: `Start a plan (/start-project)` / `Continue plan (/continue-plan)` / `Show commands overview` / `Done`
+   - Options: `Start a plan (/start-project)` / `Continue plan (/continue-plan)` / `Change workspace skin` / `Show commands overview` / `Done`
 3. Act only on the choice (point them at the matching slash command, or list key commands briefly for overview). **Stop.** Do not rewrite `onboarded`.
+4. **On `Change workspace skin`:** run **Step Skin** below, then stop (do not rewrite `onboarded`).
 
 ### Branch B: First time (marker missing or false)
 
@@ -45,22 +46,55 @@ Read `.cursor/context/config.json` (create nothing yet).
    - `/git-staging` - promote work to staging (not `main`)
    - `/git-prod` - promote approved staging to production (explicit confirm)
 
-3. Use **Ask questions** (chat fallback if tool unavailable):
+3. Run **Step Skin** (workspace chrome preference).
+
+4. Use **Ask questions** (chat fallback if tool unavailable):
    > Want to create your first plan?
    - Options: `Create first plan` / `Skip for now` / `Learn more`
 
-4. **On `Create first plan`:**
+5. **On `Create first plan`:**
    - Tell the user to run `/start-project` with their goal (1-2 sentences), **or** offer to run `/start-project`'s flow next in this chat.
    - Do **not** write a plan file inside `/onboard`.
    - Then set the marker (Step 5).
 
-5. **On `Learn more`:**
+6. **On `Learn more`:**
    - 2-4 sentences: plan with to-dos → work one phase → `/handoff` when pausing or context is full → `/git-staging` for pre-prod → `/git-prod` only after staging approval.
    - Re-ask with the same Ask questions options: `Create first plan` / `Skip for now` / `Learn more` (or omit Learn more on the re-ask if they already saw it).
 
-6. **On `Skip for now`:**
+7. **On `Skip for now`:**
    - Confirm structure is ready. They can run `/onboard` or `/start-project` later.
    - Then set the marker (Step 5).
+
+### Step Skin: Workspace skin preference
+
+Skins affect **chat tone chrome and CLI banners only** (see `docs/skins-contract.md`). They never change commits, HANDOFF, memory, or product docs. Built-ins: `registry/skins/core/` (community packs: Phase 5 / contribute docs).
+
+1. Use **Ask questions** (chat fallback if tool unavailable):
+   > Pick a workspace skin for chat/CLI chrome?
+   - Options: `Keep mode defaults (Autopilot/Night Shift/Ghost Runner per mode)` / `Autopilot` / `Night Shift` / `Ghost Runner` / `Skip for now`
+
+2. **Persist** by merging into `.cursor/context/config.json` under `workspaceSkin`. Ensure `.cursor/context/` exists. **Preserve** existing keys (`onboarded`, `autoHandoff`, `externalPlanReview`, etc.). Do not wipe the file.
+
+   | Choice | Write |
+   |--------|-------|
+   | `Keep mode defaults (...)` | Mode map from `.cursor/context/config.example.json` (`continue-plan`→autopilot, `run-plan`→night-shift, `cli-run-plan`→ghost-runner; `default`: `autopilot`) |
+   | `Autopilot` / `Night Shift` / `Ghost Runner` | Set `default` to that skin id (`autopilot` / `night-shift` / `ghost-runner`) and set **all** modes to the same id |
+   | `Skip for now` | Do not change `workspaceSkin` (leave absent or as-is) |
+
+3. Example mode-defaults payload:
+
+```json
+{
+  "workspaceSkin": {
+    "default": "autopilot",
+    "modes": {
+      "continue-plan": "autopilot",
+      "run-plan": "night-shift",
+      "cli-run-plan": "ghost-runner"
+    }
+  }
+}
+```
 
 ### Step 5: Set `onboarded` marker
 
@@ -68,13 +102,13 @@ After **Create first plan** (once bridged to `/start-project`) **or** **Skip for
 
 1. Ensure `.cursor/context/` exists.
 2. Merge into `.cursor/context/config.json`: set `"onboarded": true`.
-3. Preserve other keys (e.g. `autoHandoff`). If the file is missing, create `{ "onboarded": true }`.
+3. Preserve other keys (e.g. `autoHandoff`, `workspaceSkin`). If the file is missing, create `{ "onboarded": true }`.
 
 Do **not** set the marker on `Learn more` alone (wait for Create or Skip).
 
 ## Ask questions requirement
 
-First-session choice and the already-onboarded menu **MUST** use Ask questions (`AskQuestion` / ACP `cursor/ask_question`) instead of "type yes to continue."
+First-session skin pick, first-session plan choice, and the already-onboarded menu **MUST** use Ask questions (`AskQuestion` / ACP `cursor/ask_question`) instead of "type yes to continue."
 
 **Fallback:** if the tool is not in the session toolset, say so once, then present the same options as a numbered list. Tip: a model that supports Ask questions restores the clickable UI.
 
@@ -83,7 +117,7 @@ Kit-wide contract: [`.cursor/rules/hitl-ask-questions.mdc`](../rules/hitl-ask-qu
 ## Relationship to `/start-project`
 
 ```
-/onboard (welcome + HITL) -> user picks Create first plan
+/onboard (welcome + skin HITL + plan HITL) -> user picks Create first plan
   -> /start-project (Gate A: write plan file; Gate B: first unit)
 ```
 

--- a/.cursor/commands/run-plan.md
+++ b/.cursor/commands/run-plan.md
@@ -4,6 +4,8 @@
 
 Run the **active plan** continuously until it is done or blocked. One command; the agent picks the execution strategy. The user should not have to choose between "loop" and "orchestrated": hit `/run-plan` and follow the plan panel.
 
+**Apply workspace skin chrome.** Read `.cursor/context/config.json` for `workspaceSkin.modes.run-plan` (fallback to "night-shift"). Use the corresponding skin's `chatHints` from `registry/skins/core/` for tone and progress updates.
+
 **Never** `/git-prod` in this mode; production only with explicit confirmation (HITL).
 
 ## Strategy selection (automatic)

--- a/.cursor/rules/hitl-ask-questions.mdc
+++ b/.cursor/rules/hitl-ask-questions.mdc
@@ -24,7 +24,7 @@ Agent Kit uses **Ask questions** tool (`AskQuestion` / ACP `cursor/ask_question`
 | Surface | Gate |
 |---------|------|
 | `install.md` (Port B / drag-install) | Registry URL/ref if needed; create first plan yes/no; migrate nested `agent-kit/` confirm; optional git-hooks install |
-| `/onboard` | First-session welcome; Create first plan / Skip for now / Learn more; already-onboarded: Start a plan / Continue plan / Show commands overview / Done |
+| `/onboard` | First-session welcome; workspace skin pick (Keep mode defaults / Autopilot / Night Shift / Ghost Runner / Skip); Create first plan / Skip for now / Learn more; already-onboarded: Start a plan / Continue plan / Change workspace skin / Show commands overview / Done |
 | `context-guardian` onboarding | Defer to `/onboard` when first install / no `onboarded` marker; auto vs manual handoff preference (first time) |
 | `/start-project` | Gate A (write plan?); Gate B (start first unit / run-plan / edit); vague goal clarify |
 | `/continue-plan` | Confirm next `[to-do-id]`; if multiple plans, pick which to resume |

--- a/.cursor/rules/ux-tone.mdc
+++ b/.cursor/rules/ux-tone.mdc
@@ -10,6 +10,7 @@ alwaysApply: true
 ## Light, Direct Language
 
 - **Tone:** direct, friendly, no fluff. Like a conversation between developers.
+- **Workspace skin chrome:** When in `/continue-plan` or `/run-plan`, read `.cursor/context/config.json` for `workspaceSkin.modes` (fallback to `config.example.json` defaults). Apply the selected skin's `chatHints.tone` from `registry/skins/core/` for mode-appropriate chrome.
 - **Avoid:** "dear user", "as previously mentioned", "we would like to inform you".
 - **Use:** "let's go", "nice", "done!", "next step:", "tip:", "heads up:".
 - **Emojis:** only when they add something (checkmarks, warnings). No overuse.
@@ -43,7 +44,8 @@ alwaysApply: true
 
 - Always confirm important actions.
 - **Kit HITL gates** (install/onboarding, start-project, continue-plan, git-prod, run-plan risk, handoff preference): use **Ask questions** (`AskQuestion`), not "type yes" in chat. See [hitl-ask-questions.mdc](hitl-ask-questions.mdc). Chat fallback only if the tool is missing.
-- Progress indicators: "Working on it...", "Almost there!".
+- **Skin chrome hygiene:** Workspace skins provide chat tone only. HITL confirmation options must remain concrete labels (e.g., "Start [to-do-id]", "Switch to different plan"). Skins do not replace confirmation gates or weaken HITL contract.
+- Progress indicators: "Working on it...", "Almost there!" (or skin-appropriate equivalents from `chatHints.progress`).
 - Clear closing: "Done! Your X is now Y.".
 
 ## Examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,9 @@ jobs:
         run: pnpm build
 
   # ── Sync to public mirror (tag or manual trigger) ──
-  # Secret PUBLIC_REPO_TOKEN: fine-grained token with public repo Contents and PR write access.
+  # Secret PUBLIC_REPO_TOKEN: fine-grained token with public repo Contents,
+  # Pull requests, and merge (or auto-merge) permission. Repo must Allow auto-merge
+  # when required checks exist. Opt out: PUBLIC_SYNC_AUTO_MERGE=false.
   # The secrets context is not allowed in job-level `if`; the guard step
   # below skips gracefully when the secret is unset, so tags v* do not fail.
   sync-public:
@@ -88,6 +90,8 @@ jobs:
           PUBLIC_REPO_URL: ${{ vars.PUBLIC_REPO_URL || 'https://github.com/agent-kit-startup/agent-kit.git' }}
           PUBLIC_REPO_SLUG: agent-kit-startup/agent-kit
           PUBLIC_BRANCH: main
+          # Default: auto-merge after create/update. Set repo/org var to "false" to opt out.
+          PUBLIC_SYNC_AUTO_MERGE: ${{ vars.PUBLIC_SYNC_AUTO_MERGE || 'true' }}
           GIT_AUTHOR_NAME: agent-kit-sync
           GIT_AUTHOR_EMAIL: sync@agent-kit.dev
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 
 ## [Unreleased]
 
+## [4.4.1] - 2026-07-22
+
+### Fixed
+
+- CLI: Biome lint/format on `skin-banners` unit test and related `init`/`prompts` format drift (non-null assertions blocked CI `build` after `v4.4.0`, which skipped `publish-npm` and `sync-public`)
+
+## [4.4.0] - 2026-07-21
+
+### Added
+
+- Skins: built-in packs `autopilot`, `night-shift`, and `ghost-runner` under `registry/skins/core/` (schema in `registry/schemas/skin-pack.json`; index in `registry/skins/core/index.json`)
+- Skins: mode-aware chat chrome integration in `/continue-plan` and `/run-plan` commands; workspace skin configuration reading from `.cursor/context/config.json` with built-in pack fallbacks
+- CLI: `agent-kit run-plan` tick banners from `workspaceSkin.modes["cli-run-plan"]` (default `ghost-runner`); loads `registry/skins/core/<id>/skin.json`, kolorist-only coloring, fail-soft to plain logs when the skin file is missing
+- Docs: `docs/skins-contract.md` workspace skins schema, mode defaults, acceptance rules, and hygiene boundary; `workspaceSkin` keys in `.cursor/context/config.example.json`
+- Commands: `/onboard` Ask questions workspace skin pick (Keep mode defaults / Autopilot / Night Shift / Ghost Runner / Skip); merges `workspaceSkin` into `.cursor/context/config.json` without wiping other keys; already-onboarded menu includes `Change workspace skin`
+- CLI: `agent-kit init` wizard optional clack select for the same skin preference; writes `workspaceSkin` into `.cursor/context/config.json` (merge-safe)
+- Docs: `docs/public-launch-announcement.md` copy-paste public launch text; indexed from `docs/README.md` and linked from `docs/public-launch.md`
+- Docs: `docs/creating-skins.md` skin pack format, placement, contribute checklist; indexed from `docs/README.md`, `docs/CONTRIBUTING.md`, and `docs/contribute-upstream.md`
+
+### Changed
+
+- Rules: enhanced `ux-tone.mdc` with workspace skin chrome guidance and HITL confirmation hygiene (skins affect chat tone only, never confirmation options)
+- Rules: `hitl-ask-questions` `/onboard` gate lists workspace skin pick and `Change workspace skin`
+- Docs/meta: product identity says HITL framework (not developer bootstrapper) in `docs/README.md`, `docs/CONTRIBUTING.md`, root + CLI `package.json`, CLI banner, and `docs/cursor-native-audit.md` plugin description row
+- Docs: renamed launch copy from channel-specific `public-launch-whatsapp.md` to channel-agnostic `public-launch-announcement.md`
+- Docs: storefront claims for `/onboard` and `/start-project` match Ask questions + chat fallback, HITL gates, and Context Guardian wording (README, getting-started, bootstrap)
+- Sync: public sync PRs get a semantic body (Summary + CHANGELOG release notes + source SHA) and auto-merge by default (`gh pr merge --auto`); opt out with `PUBLIC_SYNC_AUTO_MERGE=false`
+- Docs: `/git-prod` requires annotated `vX.Y.Z` tag push after private `main` (triggers `publish-npm` + `sync-public`); public sync auto-merge documented in checklist and repository boundaries
+- Sync: `scripts/sync-public.mjs` runs git via `execFileSync` argv arrays (no shell-string interpolation for branch/remote/url/message)
+- Docs: consumer install notes version pin for unpinned `npx @dadado/agent-kit-cli` (README, install.md, getting-started)
+- Docs: plan execution security note (`cursor-agent --sandbox disabled` access; registry trust model for external contributions) in getting-started and repository-boundaries
+
 ## [4.3.0] - 2026-07-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ Run from your project root:
 npx @dadado/agent-kit-cli install
 ```
 
+Unpinned `npx` resolves to the latest publish. Pin a version when you need a reproducible install: `npx @dadado/agent-kit-cli@x.y.z install` (replace `x.y.z` with a version from npm).
+
 That's it. You now have a handful of slash commands and a small set of rules. Full walkthrough: [docs/getting-started.md](docs/getting-started.md).
 
 ## Usage
 
-1. **First-time setup:** `/onboard` - welcome and command introduction (then `/start-project` when you have a goal).
-2. **Start a plan:** `/start-project` - Broad Intake Review, propose/write the plan first, then run the first to-do only after you confirm.
+1. **First-time setup:** `/onboard` - welcome with clickable options via Ask questions tool; sets onboarded marker (then `/start-project` when you have a goal).
+2. **Start a plan:** `/start-project` - Broad Intake Review, then two gates with Ask questions: (A) write plan file, (B) run first unit only after explicit confirmation.
 3. **Work one phase:** agent implements the current phase, updates handoff, and stops.
 4. **Continue later:** `/continue-plan` in a fresh chat picks up where you left off.
 5. **Ship to staging:** `/git-staging` - branches, commits, merges automatically.

--- a/autogit/gitupdate.md
+++ b/autogit/gitupdate.md
@@ -379,6 +379,12 @@ This section contains the detailed prompts that should be followed when commands
    - **NEVER** force push (`--force` or `--force-with-lease`) without explicit user authorization.
    - Prefer `ALLOW_MAIN_PUSH=1` over `--no-verify` so other hooks still run.
 
+#### 9.5. **Create and push annotated tag (when absent)**  
+   - Check if tag exists for current version: `git tag -l "v<version>"` where `<version>` matches `package.json`.
+   - If tag does not exist, create annotated tag: `git tag -a v<version> -m "Release v<version>"` on the current main commit.
+   - Push the tag: `git push origin v<version>`.
+   - **Effect**: Annotated vX.Y.Z tags trigger CI `publish-npm` job (when `NPM_TOKEN` configured) and `sync-public` workflow (when `PUBLIC_REPO_TOKEN` configured).
+
 #### 10. **Sync staging (optional)**  
    - Run `git checkout staging` to return to staging branch.
    - Run `git merge --ff-only origin/main` to sync staging with main (if applicable).
@@ -393,7 +399,8 @@ This section contains the detailed prompts that should be followed when commands
    - **If** the project has PM tool MCP/skill configured: update status of promotion-related tasks (e.g., "completed"). No tool or no tasks: skip without warning.
 
 #### 12. **Public mirror sync (this monorepo)**  
-   - With `public` remote configured and `gh` authenticated, run **`pnpm git:trigger-public-sync`** (or `bash scripts/trigger-public-sync-after-prod.sh`) to trigger CI workflow with public repository sync. See `docs/repository-boundaries.md`.
+   - **Primary**: Annotated vX.Y.Z tag (step 9.5) automatically triggers `sync-public` CI when `PUBLIC_REPO_TOKEN` is configured.
+   - **Fallback**: If tag was not created or manual dispatch needed, run **`pnpm git:trigger-public-sync`** (or `bash scripts/trigger-public-sync-after-prod.sh`) to trigger CI workflow with public repository sync. See `docs/repository-boundaries.md`.
    - In projects without public mirror, skip this step.
 
 #### 13. **Final Report**  

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Agent Kit is a developer bootstrapper for AI-assisted IDEs. Contributions welcome - from skills to CLI features to docs.
+Agent Kit is a HITL framework for AI-assisted IDEs. Contributions welcome - from skills to CLI features to docs.
 
 ## Setup
 
@@ -62,7 +62,13 @@ See [repository-boundaries.md](repository-boundaries.md): daily Git targets the 
 
 ## Registry contributions (marketplace catalog)
 
+### Skills
+
 Add community skills under `registry/skills/community/<skill-id>/SKILL.md`. Core skills need maintainer review (`registry/skills/core/`).
+
+### Skins
+
+Add community workspace skins under `registry/skins/community/<skin-id>/skin.json`. See [creating-skins.md](creating-skins.md) for format and acceptance rules.
 
 ### New skill vs improving an existing one
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Agent Kit Docs
 
-Agent Kit is a developer bootstrapper for AI-assisted IDEs. It understands your project, finds what's missing, and generates tailored setup for Cursor, VS Code, and Windsurf - then helps you develop without losing context.
+Agent Kit is a HITL framework for AI-assisted IDEs: plan, handoff, staging-to-prod git flow, and memory across long projects. Install generates project-aware setup for Cursor, VS Code, and Windsurf.
 
 ## Guides
 
@@ -9,10 +9,13 @@ Agent Kit is a developer bootstrapper for AI-assisted IDEs. It understands your 
 - [Migrate consumer](migrate-consumer.md) - generic runbook to leave nested `agent-kit/` (`YOUR_PROJECT`)
 - [Contribute upstream](contribute-upstream.md) - `agent-kit contribute` return channel + gate
 - [Public launch](public-launch.md) - go/no-go + append-only sync
+- [Public launch announcement](public-launch-announcement.md) - copy-paste launch text (chat / social)
 - [Topology private × public](topology-private-public.md) - Fase 7 registry-canonical public
 - [Marketplace catalog](marketplace.md) - versioning, CLI add, Cursor plugin, quality gate
 - [Review layers](review-camadas.md) - final HITL / go-no-go pass
 - [Creating Skills](creating-skills.md) - skill format, placement, registry
+- [Creating Skins](creating-skins.md) - skin pack format, placement, contribute checklist
+- [Workspace skins contract](skins-contract.md) - skin pack schema, mode defaults, acceptance rules
 - [Cursor 3.0 Features](cursor-3-features.md) - how Agent Kit uses native IDE features
 - [Cursor-native audit](cursor-native-audit.md) - hooks.json, plugin, rule modes, VS Code/Windsurf gaps
 - [Coherence inventory](coherence-inventory.md) - classification of rules, skills, hooks, agents, commands

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -52,7 +52,7 @@ What `install` does:
 3. Optionally adds any packs you asked for with `--pack`.
 4. Writes `.cursor/agent-kit.json` recording the version and which of your files to leave untouched on update.
 
-**No CLI on your PATH?** Open the project in your IDE, attach the root [`install.md`](../install.md), and ask the agent to install. It produces the same files and manifest. After install (CLI or chat), the first step is `/onboard` for first-time setup and command introduction. Chat install and onboarding use **Ask questions** (clickable options in the IDE) for confirmations and choices, with a chat fallback if the tool is unavailable. The CLI path (`agent-kit init` / install wizard) keeps `@clack/prompts` in the terminal; it does not call IDE Ask questions.
+**No CLI on your PATH?** Open the project in your IDE, attach the root [`install.md`](../install.md), and ask the agent to install. It produces the same files and manifest. After install (CLI or chat), the first step is `/onboard` for first-time setup and command introduction with Ask questions tool. Chat install and onboarding use **Ask questions** (clickable options in the IDE, with chat fallback when tool unavailable) for confirmations and choices. The CLI path (`agent-kit init` / install wizard) keeps `@clack/prompts` in the terminal; it does not call IDE Ask questions.
 
 ## Keeping it current
 

--- a/docs/contribute-upstream.md
+++ b/docs/contribute-upstream.md
@@ -6,6 +6,7 @@ Return channel from a **consumer project** back to the Agent Kit registry. Compl
 
 - You edited an installed L0 / pack / skill file and the change should be shared (not kept as a silent fork).
 - You authored a new skill under `.cursor/skills/...` that belongs in `registry/skills/`.
+- You created a workspace skin that belongs in `registry/skins/community/`.
 - Golden rule from layers-spec: do **not** hand-edit kit files as a permanent project fix - override via L3 **or** contribute upstream.
 
 ## Flow
@@ -61,8 +62,9 @@ Rejected when any of these apply:
 |--------------|---------------|
 | L0 / pack member targets | Same relative path (or pack `source`) |
 | `.cursor/skills/<cat>/<id>/SKILL.md` | `registry/skills/<cat>/<id>/SKILL.md` (guessed when not in manifest) |
+| `.cursor/skins/<id>/skin.json` | `registry/skins/community/<id>/skin.json` (community skins only) |
 
-New skills still need a `registry/registry.json` entry (and pack membership if applicable) - update those in the PR.
+New skills still need a `registry/registry.json` entry (and pack membership if applicable) - update those in the PR. Skins are discovered by directory structure and do not require registry entries.
 
 ## Target repo (after Phase B)
 

--- a/docs/creating-skins.md
+++ b/docs/creating-skins.md
@@ -1,0 +1,75 @@
+# Creating Skins
+
+Workspace skins provide execution mode-specific UX chrome for Agent Kit while preserving professional output. They affect chat tone and CLI banners only, never commits, HANDOFF, memory, or product documentation.
+
+## Skin Pack Format
+
+Each skin pack provides a JSON configuration with:
+
+```json
+{
+  "id": "string",
+  "displayName": "string", 
+  "intent": "string",
+  "chatHints": {
+    "tone": "string",
+    "confirmation": "string",
+    "progress": "string"
+  },
+  "cliBanners": {
+    "tickStart": "string",
+    "tickEnd": "string", 
+    "phaseComplete": "string"
+  },
+  "ansiPalette": {
+    "primary": "string",
+    "secondary": "string",
+    "accent": "string"
+  }
+}
+```
+
+See [skins-contract.md](skins-contract.md) for detailed schema constraints and acceptance rules.
+
+## Where to place
+
+- **Core skins:** `registry/skins/core/` (first-party, built-in)
+- **Community skins:** `registry/skins/community/` (community contributions)
+
+Each skin pack lives in its own folder: `registry/skins/{category}/{skin-id}/skin.json`
+
+## Acceptance rules
+
+Skin packs must comply with these requirements:
+
+1. **Surface scope**: Chat UX chrome and CLI banners only
+2. **Token efficiency**: Brief messages respecting ux-tone guidelines  
+3. **Professional boundary**: No impact on commits, HANDOFF, memory, product docs
+4. **Schema compliance**: Valid against `registry/schemas/skin-pack.json`
+5. **Content standards**: No secrets, personal references, or em dash connectors
+
+Full acceptance criteria detailed in [skins-contract.md](skins-contract.md).
+
+## Registry discovery
+
+Skins are installed via workspace configuration in `.cursor/context/config.json`. Users select workspace skin preferences during `/onboard` or by editing configuration directly. 
+
+Unlike skills and packs, skins do not require `registry.json` entries. They are discovered by directory structure under `registry/skins/`.
+
+## Contribute checklist
+
+When submitting a community skin pack:
+
+- [ ] Valid JSON against `registry/schemas/skin-pack.json`
+- [ ] No secrets or agent metalanguage  
+- [ ] Professional tone (no personal references, em dash connectors)
+- [ ] UX density limits respected (chat hints ≤50 chars, CLI banners ≤40 chars)
+- [ ] Intent clearly describes when to use this skin
+- [ ] Display name under 30 characters
+- [ ] Skin ID follows kebab-case pattern (3-20 characters)
+- [ ] Chat hints enhance UX without breaking token efficiency
+- [ ] CLI banners provide optional theming without breaking core functionality
+- [ ] Hygiene boundary maintained (presentation layer only)
+- [ ] No impact on technical content (commits, memory, docs)
+
+Submit via PR to the `registry/skins/community/` directory. Maintainers review for compliance with acceptance rules and may suggest adjustments before merge.

--- a/docs/cursor-native-audit.md
+++ b/docs/cursor-native-audit.md
@@ -27,7 +27,7 @@ Audit of Cursor-specific artifacts in the Agent Kit repository: what exists, wha
 |-------|-------|
 | name | `agent-kit` |
 | version | `3.0.0` |
-| description | Multi-IDE bootstrapper (Cursor, VS Code, Windsurf) |
+| description | HITL framework for AI-assisted IDEs (plan, handoff, staging→prod, memory loop) |
 
 **Findings:**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,6 +10,8 @@ Run this from your project's root folder:
 npx @dadado/agent-kit-cli install
 ```
 
+Unpinned `npx` resolves to the latest publish. Pin a version when you need a reproducible install: `npx @dadado/agent-kit-cli@x.y.z install` (replace `x.y.z` with a version from npm).
+
 That's the whole install. It drops a small set of rules and slash commands into `.cursor/`, a git routine into `autogit/`, and a manifest (`.cursor/agent-kit.json`) that records what was installed so the kit can update itself later without touching your work.
 
 Want a few extra bundles up front? Add packs (clean code, context tools, and more - see [domain packs](domain-packs.md)):
@@ -18,7 +20,7 @@ Want a few extra bundles up front? Add packs (clean code, context tools, and mor
 npx @dadado/agent-kit-cli install --pack clean-code,context-management
 ```
 
-**Prefer chat install?** Copy-paste the installer brief from the [README](../README.md#install) into Cursor chat. You get exactly the same result. The chat installer uses **Ask questions** for confirmations (clickable options in IDE UI), while the CLI uses terminal prompts.
+**Prefer chat install?** Copy-paste the installer brief from the [README](../README.md#install) into Cursor chat. You get exactly the same result. The chat installer uses **Ask questions** for confirmations (clickable options in IDE UI, with chat fallback when tool unavailable), while the CLI uses terminal prompts.
 
 > Don't clone the Agent Kit repo into your project. Installing writes only the files your project needs - see [bootstrap](bootstrap.md) for the exact layout.
 
@@ -46,9 +48,9 @@ npx @dadado/agent-kit-cli init
 
 The idea is simple: work against a plan, save your place before a conversation gets too big, and (in manual mode) keep **one phase per chat**.
 
-0. **`/onboard`** *(first time only)* - Welcome and introduction to core commands. Path after CLI install: open the folder in Cursor → `/onboard` → `/start-project`.
-1. **`/start-project`** - Broad Intake Review, then two gates using **Ask questions**: (A) the agent proposes and writes a plan with checkable to-dos (no coding yet); (B) only after you confirm, it runs the **first** unit. Uses clickable options instead of "type yes to continue". Goal text in the same message is not a green light to edit the repo.
-2. **Work one phase.** The agent implements the current phase (or one heavy to-do), checks it off, updates `.cursor/HANDOFF.md`, and stops. Soft rules plus **native Cursor hooks** (`sessionStart` / `preCompact`) reinforce that boundary; multi-phase in one window needs an explicit mode below.
+0. **`/onboard`** *(first time only)* - Welcome and introduction to core commands via **Ask questions** tool (clickable options); sets onboarded marker. Path after CLI install: open the folder in Cursor → `/onboard` → `/start-project`.
+1. **`/start-project`** - Broad Intake Review, then two gates using **Ask questions**: (A) the agent proposes and writes a plan with checkable to-dos (no coding yet); (B) only after you confirm, it runs the **first** unit. Uses clickable options with chat fallback when tool unavailable. Goal text in the same message is not execute permission.
+2. **Work one phase.** The agent implements the current phase (or one heavy to-do), checks it off, updates `.cursor/HANDOFF.md`, and stops. Context Guardian plus **native Cursor hooks** (`sessionStart` / `preCompact`) enforce that boundary; multi-phase in one window needs an explicit mode below.
 3. **`/handoff`** - when the chat is getting long (or the IDE is about to compact context), the agent writes down where things stand (and suggests pushing to staging if there's something worth committing).
 4. **New chat → `/continue-plan`** - it reads the handoff and continues, without you re-explaining the project.
 
@@ -68,6 +70,10 @@ When `/run-plan` finishes all implementable to-dos, you can get a second-agent c
 4. **Triage:** After Claude writes a monitor file, use `/plan-review-triage` to process findings with clickable options
 
 This requires Claude Code CLI on your PATH. If disabled or Claude is missing, the kit continues normally without external review.
+
+### Security considerations
+
+**Plan execution runs with sandbox disabled:** The continuous plan execution (`/run-plan`) uses `cursor-agent --sandbox disabled` to access filesystem operations, git commands, and project tools. This is required for the agent to implement code changes and commit to staging. Maintainers should review plan to-dos and registry skills before enabling continuous execution, as these function as direct agent instructions.
 
 The exact git steps behind staging and production live in `autogit/gitupdate.md`; plan modes in `autogit/plan-routine.md`. Both are installed with the kit. Native hooks are listed in [layers-spec.md](layers-spec.md) (L0).
 

--- a/docs/npm-publish-checklist.md
+++ b/docs/npm-publish-checklist.md
@@ -45,7 +45,7 @@ The `publish-npm` job in `.github/workflows/ci.yml` runs on **`v*` tags** only. 
 - [ ] Tags use the form **`vMAJOR.MINOR.PATCH`** (e.g. `v4.2.1`).
 - [ ] **Existing tags on `origin`:** `v4.0.0`, `v4.0.1`, `v4.1.0`, `v4.2.0`, `v4.2.1`. Pushing a **new** `v*` tag (or re-running CI for a tag) triggers `publish-npm` after `build` succeeds.
 - [ ] Tag the commit on `main` that matches the release version; do not tag staging-only commits unless that is an explicit exception documented in the release notes.
-- [ ] Prefer creating the tag locally only after checklist sign-off, then push with `git push origin vX.Y.Z` (or use GitHub Releases UI with equivalent tag name).
+- [ ] **Integrated with `/git-prod`**: Annotated tags are created automatically when absent during `/git-prod` workflow (step 9.5 in `autogit/gitupdate.md`). Manual tag creation via `git push origin vX.Y.Z` or GitHub Releases UI is fallback only.
 
 ## Local dry-run (no upload)
 

--- a/docs/public-launch-announcement.md
+++ b/docs/public-launch-announcement.md
@@ -1,0 +1,47 @@
+# Public launch announcement
+
+Copy-paste text for announcing the public repository (chat, social, communities). Portuguese body is the shippable launch copy; keep product claims aligned with [getting-started.md](getting-started.md) and the root `README.md`.
+
+Related: [Public launch go/no-go](public-launch.md).
+
+```text
+Fala, devs! 🚀
+
+Se você usa o Cursor ou outro IDE com IA assistida para codar, já deve ter passado pelo clássico problema de ver a IA se perder e alucinar quando o chat fica muito longo e o contexto enche. 🤯
+
+Para resolver esse e outros problemas, como a falta de um fluxo de DevOps estruturado, conexão segura com ferramentas e versionamento, ao longo de um ano, fui desenvolvendo o *Agent Kit*! 🛠️
+
+Diga-se de passagem, meu primeiro repositório público. 🥶
+
+*🤔 O que é o Agent Kit?*
+É uma camada operacional leve que transforma seu IDE (Cursor, VS Code, etc.) em um framework que gerencia o planejamento, o handoff entre chats e o fluxo de Git / DevOps estruturado para você focar no que importa.
+
+*✨ O que ele resolve?*
+• *Onboarding & Setup Inteligente:* Ele analisa o seu projeto, descobre o que está faltando e gera regras, comandos e skills personalizados sob medida para a sua stack e padrões de código. 🧠✨
+• *Sem perda de contexto:* Ele mantém o estado do seu projeto vivo. Abriu um chat novo? Um comando e a IA já sabe exatamente onde parou. 🔄
+• *Planos de verdade:* "vibecoding" mas nem tanto. A IA trabalha em cima de to-dos reais que você acompanha passo a passo no loop. 📋
+• *DevOps integrado:* Fluxo de Git seguro com staging automático e commits limpos. 🛡️
+• *Segurança em produção:* A IA pode subir para staging sozinha, mas promover para `main` sempre exige sua confirmação direta. Hooks nativos protegem a IA de fazer isso alucinando. 🛑
+
+*🚀 Como usar?*
+É simples e rápido de instalar o projeto:
+
+1️⃣ *No terminal do seu projeto, rode:*
+`npx @dadado/agent-kit-cli install`
+
+2️⃣ *Ou no chat do Cursor, cole o prompt de instalação rápida:*
+(Se for preguiçoso feito eu, encontre o prompt completo no README e LEIA antes de executar, mané!)
+
+Depois de instalado, você ganha comandos como `/onboard`, `/start-project` e `/continue-plan` diretamente no chat do seu editor.
+
+---
+
+💡 *Quer contribuir?*
+O projeto é 100% open-source! Achou um bug, tem ideias de novos comandos ou quer criar regras/skills personalizadas para a sua stack? Abre uma Issue ou manda uma PR lá no GitHub. Toda contribuição é muito bem-vinda! 🤝
+
+👉 *Bora testar e dar aquela estrela no GitHub?*
+Acesse o repositório oficial, veja a documentação completa e comece a usar agora:
+https://github.com/agent-kit-startup/agent-kit
+
+Show? Se testar, me conta o que achou! 👊🔥
+```

--- a/docs/public-launch.md
+++ b/docs/public-launch.md
@@ -1,6 +1,6 @@
 # Public launch - go/no-go
 
-Checklist before promoting or advertising the public mirror ([agent-kit-startup/agent-kit](https://github.com/agent-kit-startup/agent-kit)). For topology and cutover status, see [topology-private-public.md](topology-private-public.md).
+Checklist before promoting or advertising the public mirror ([agent-kit-startup/agent-kit](https://github.com/agent-kit-startup/agent-kit)). For topology and cutover status, see [topology-private-public.md](topology-private-public.md). Ready-to-paste launch copy: [public-launch-announcement.md](public-launch-announcement.md).
 
 ## History mode (decision)
 
@@ -86,17 +86,23 @@ node scripts/sync-public.mjs --dry-run
 # Review every path; prohibited patterns must not appear.
 ```
 
-## Sync (HITL)
+## Sync (automated)
 
-After `git prod` on the private repo (or `workflow_dispatch`):
+After `git prod` on the private repo, the pipeline automatically:
 
+1. **Creates annotated vX.Y.Z tag** (triggers npm publish + sync-public jobs)
+2. **Opens sync PR** with semantic body: Summary + CHANGELOG release notes + source SHA
+3. **Auto-merges PR** after required checks pass (`gh pr merge --auto`)
+
+Opt-out: Set `PUBLIC_SYNC_AUTO_MERGE=false` to require manual merge.
+
+Manual fallback:
 ```bash
-# default: push a sync branch and open a PR
+# workflow_dispatch when tag-based trigger is insufficient
+pnpm git:trigger-public-sync
+
+# direct commands (rare)
 node scripts/sync-public.mjs --url "$PUBLIC_REPO_URL"
-
-# migration only, before main is protected
-node scripts/sync-public.mjs --direct --url "$PUBLIC_REPO_URL"
-
-# nuclear rebuild only if public history must be discarded
-node scripts/sync-public.mjs --force-snapshot --url "$PUBLIC_REPO_URL"
+node scripts/sync-public.mjs --direct --url "$PUBLIC_REPO_URL"  # migration only
+node scripts/sync-public.mjs --force-snapshot --url "$PUBLIC_REPO_URL"  # escape hatch
 ```

--- a/docs/repository-boundaries.md
+++ b/docs/repository-boundaries.md
@@ -37,9 +37,11 @@ Do not `git add -f` session paths. Contributions after Phase B: registry PRs go 
 ## Flow: `git staging` → `git prod` → public
 
 1. **`git staging`** - PR to `staging` on the **private** repo (`agent-kit-dev`). Everything committed goes to private.
-2. **`git prod`** - `staging` → `main` on **private**; push `origin main`.
-3. **Public mirror (integrated into `git prod`)** - With a `public` remote pointing at the public GitHub repo and `gh` authenticated, after pushing `main` run **`pnpm git:trigger-public-sync`** (or `bash scripts/trigger-public-sync-after-prod.sh`): triggers the **CI** workflow on **origin** with *Sync to public repo* → CI runs **build** and opens a sync PR on public (requires `PUBLIC_REPO_TOKEN` on private). See step 12 of "Prompt: git prod" in `autogit/gitupdate.md`.
-4. **Alternatives** (release or fallback): SemVer `v*` tag on private; manual *workflow_dispatch* in Actions; `node scripts/sync-public.mjs` with URL/token in the environment.
+2. **`git prod`** - `staging` → `main` on **private**; push `origin main`; create/push annotated vX.Y.Z tag when absent.
+3. **Automatic triggers** - Annotated `v*` tags trigger both `publish-npm` (when `NPM_TOKEN` configured) and `sync-public` (when `PUBLIC_REPO_TOKEN` configured) CI jobs.
+4. **Public sync PR** - Creates semantic PR body (Summary + CHANGELOG release notes + source SHA) against public `main`.
+5. **Auto-merge** - PRs auto-merge after required checks pass (`gh pr merge --auto`). Set `PUBLIC_SYNC_AUTO_MERGE=false` to require manual merge.
+6. **Fallback** (manual dispatch): `pnpm git:trigger-public-sync` or *workflow_dispatch* in Actions when tag-based trigger is insufficient.
 
 Without `PUBLIC_REPO_TOKEN` configured on the **private** GitHub repo, the sync job pushes nothing; the rest of CI still runs normally.
 
@@ -87,6 +89,10 @@ Optional repository variable `PUBLIC_REPO_URL` overrides the default public Git 
 
 - **Phase A (legacy):** external PRs on public; maintainers merge and, if needed, promote-back into private before the next sync overwrites registry paths. ⚠️ **Being phased out**
 - **Phase B (complete):** registry PRs must target public; private registry sync no longer publishes; contribute surfaces are public-first.
+
+### Trust model
+
+Registry skills and rules are agent instructions executed with filesystem and git access. External contributions should be reviewed for unintended side effects before merge. Plan execution runs agents with `--sandbox disabled` to enable code implementation and git operations required for the development workflow.
 
 ## FAQ: Private vs Public roles
 

--- a/docs/skins-contract.md
+++ b/docs/skins-contract.md
@@ -1,0 +1,128 @@
+# Workspace Skins Contract
+
+## Overview
+
+Workspace skins provide execution mode-specific UX chrome for Agent Kit while preserving professional output hygiene. Skins affect chat tone and CLI banners only, never commits, HANDOFF, memory, or product documentation.
+
+## Skin Pack Schema
+
+Each skin pack defines:
+
+```json
+{
+  "id": "string",
+  "displayName": "string", 
+  "intent": "string",
+  "chatHints": {
+    "tone": "string",
+    "confirmation": "string",
+    "progress": "string"
+  },
+  "cliBanners": {
+    "tickStart": "string",
+    "tickEnd": "string", 
+    "phaseComplete": "string"
+  },
+  "ansiPalette": {
+    "primary": "string",
+    "secondary": "string",
+    "accent": "string"
+  }
+}
+```
+
+### Field Constraints
+
+- **id**: kebab-case identifier, 3-20 characters
+- **displayName**: user-friendly name, max 30 characters
+- **intent**: purpose description, max 100 characters
+- **chatHints**: optional UX guidance strings, max 50 characters each
+- **cliBanners**: optional CLI output prefixes, max 40 characters each
+- **ansiPalette**: optional ANSI color codes for terminal theming
+
+## Mode Defaults (Locked)
+
+| Execution Mode | Surface | Default Skin |
+|----------------|---------|--------------|
+| Manual chat | `/continue-plan` | autopilot |
+| Continuous chat | `/run-plan` | night-shift |
+| Headless CLI | `agent-kit run-plan` | ghost-runner |
+
+## Configuration
+
+Workspace skin preferences stored in `.cursor/context/config.json`:
+
+```json
+{
+  "workspaceSkin": {
+    "default": "autopilot",
+    "modes": {
+      "continue-plan": "autopilot",
+      "run-plan": "night-shift",
+      "cli-run-plan": "ghost-runner"
+    }
+  }
+}
+```
+
+Users select workspace skin during `/onboard` (or `agent-kit init` wizard) or by editing configuration directly. Community contribute path: Phase 5 (`docs/creating-skins.md` when published).
+
+## Acceptance Rules
+
+### Pattern Requirements
+
+1. **Surface scope**: Chat UX chrome and CLI banners only
+2. **Token efficiency**: Brief messages respecting ux-tone guidelines
+3. **Fallback graceful**: Missing skin defaults to neutral tone
+4. **Mode awareness**: Skin selection based on execution context
+
+### Content Standards
+
+1. **Professional boundary**: No impact on commits, HANDOFF, memory, product docs
+2. **No secrets**: Skin packs contain no sensitive information
+3. **No personal references**: Generic terms only, no people names
+4. **No em dash connectors**: Use hyphens, colons, or parentheses
+5. **Repository hygiene**: Skins live in registry, not workspace commits
+
+### UX Density Requirements
+
+- Chat hints: Max 3 sentences per message
+- CLI banners: Single line prefixes
+- Progress indicators: Consistent format across modes
+- Error messages: Clear next steps, no blame language
+
+## Hygiene Invariant
+
+Skins affect presentation layer only. Technical content including:
+
+- Commit messages and CHANGELOG entries
+- HANDOFF operational instructions  
+- Memory entries (errors/decisions)
+- Product documentation voice
+- ADR and technical decision records
+
+Must follow existing professional standards regardless of active skin.
+
+## Implementation Phases
+
+1. **Phase 0**: Contract design (this document)
+2. **Phase 1**: Built-in skin packs (autopilot, night-shift, ghost-runner)
+3. **Phase 2**: Chat mode integration (/continue-plan, /run-plan)
+4. **Phase 3**: CLI integration (agent-kit run-plan)
+5. **Phase 4**: Onboard selection flow
+6. **Phase 5**: Community contribution path
+
+## Registry Location
+
+- Built-in skins: `registry/skins/core/`
+- Community skins: `registry/skins/community/`
+- Schema validation: `registry/schemas/skin-pack.json`
+
+## Validation
+
+Skin packs validated on contribution:
+
+1. Schema compliance (required fields, length limits)
+2. Content standards (no secrets, professional tone)
+3. UX density (token efficiency, clear messaging)  
+4. Hygiene boundary (presentation only, no technical content)

--- a/install.md
+++ b/install.md
@@ -16,6 +16,8 @@ If Node.js is available, in the **consumer project root**:
 npx @dadado/agent-kit-cli install
 ```
 
+Unpinned `npx` resolves to the latest publish. Pin a version when you need a reproducible install: `npx @dadado/agent-kit-cli@x.y.z install` (replace `x.y.z` with a version from npm).
+
 Optional L1 packs (separate command):
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-kit",
-  "version": "4.3.0",
-  "description": "Developer bootstrapper for AI-assisted IDEs — understands your project, generates tailored setup for Cursor/VS Code/Windsurf, and helps you develop without losing context.",
+  "version": "4.4.1",
+  "description": "HITL framework for AI-assisted IDEs: plan, handoff, staging-to-prod, memory loop; project-aware setup for Cursor, VS Code, and Windsurf.",
   "private": true,
   "license": "MIT",
   "packageManager": "pnpm@10.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dadado/agent-kit-cli",
-  "version": "4.3.0",
-  "description": "Agent Kit CLI — bootstraps AI-assisted IDEs with project-aware rules, skills, and context management",
+  "version": "4.4.1",
+  "description": "Agent Kit CLI: HITL framework install and tooling for AI-assisted IDEs (rules, skills, plan/handoff, context).",
   "type": "module",
   "bin": {
     "agent-kit": "./dist/index.js"

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -5,9 +5,27 @@ import { generateFromProfile } from "../generator/index.js";
 import { installSkillsByIds } from "../registry/install.js";
 import { resolveRegistryRoot } from "../registry/resolve.js";
 import { runScanner } from "../scanner/scan.js";
-import { writeJson } from "../utils/fs.js";
+import type { WorkspaceSkinConfig } from "../types.js";
+import { ensureDir, readJson, writeJson } from "../utils/fs.js";
 import { logger } from "../utils/logger.js";
-import { runExistingProjectWizard, runGreenfieldWizard } from "../utils/prompts.js";
+import {
+  runExistingProjectWizard,
+  runGreenfieldWizard,
+  workspaceSkinConfigFromChoice,
+} from "../utils/prompts.js";
+
+/** Merge `workspaceSkin` into `.cursor/context/config.json` without wiping other keys. */
+async function mergeWorkspaceSkinConfig(
+  rootDir: string,
+  workspaceSkin: WorkspaceSkinConfig,
+): Promise<string> {
+  const contextDir = path.join(rootDir, ".cursor", "context");
+  const configPath = path.join(contextDir, "config.json");
+  await ensureDir(contextDir);
+  const existing = (await readJson<Record<string, unknown>>(configPath)) ?? {};
+  await writeJson(configPath, { ...existing, workspaceSkin });
+  return configPath;
+}
 
 export const initCommand = defineCommand({
   meta: {
@@ -34,9 +52,17 @@ export const initCommand = defineCommand({
       ? await runGreenfieldWizard(scan)
       : await runExistingProjectWizard(scan);
 
+    const { workspaceSkinChoice, ...profileToSave } = profile;
     const configPath = path.join(scan.rootDir, ".cursor", "agent-kit.config.json");
-    await writeJson(configPath, profile);
+    await writeJson(configPath, profileToSave);
     logger.success(`Profile saved in ${configPath}`);
+
+    const skinConfig =
+      workspaceSkinChoice !== undefined ? workspaceSkinConfigFromChoice(workspaceSkinChoice) : null;
+    if (skinConfig) {
+      const contextConfigPath = await mergeWorkspaceSkinConfig(scan.rootDir, skinConfig);
+      logger.success(`Workspace skin saved in ${contextConfigPath}`);
+    }
 
     await generateFromProfile(profile);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,7 +14,7 @@ import { updateCommand } from "./commands/update.js";
 const main = defineCommand({
   meta: {
     name: "agent-kit",
-    description: "Developer bootstrapper for AI-assisted IDEs",
+    description: "HITL framework for AI-assisted IDEs",
   },
   subCommands: {
     init: initCommand,

--- a/packages/cli/src/plan-loop/run-loop.ts
+++ b/packages/cli/src/plan-loop/run-loop.ts
@@ -10,6 +10,7 @@ import {
 } from "./external-review.js";
 import { countPendingTodos, findActivePlanFile, readPlan } from "./plan-state.js";
 import { formatSentinelLine, parseSentinelFromLogFile } from "./sentinel.js";
+import { createSkinBannerPrinter, loadCliRunPlanSkin } from "./skin-banners.js";
 
 export const TICK_PROMPT =
   '/run-plan - single tick from the headless runner (agent-kit run-plan). Read .cursor/HANDOFF.md and the active plan in .cursor/plans/. Mark the next to-do as in_progress in the frontmatter, execute ONLY that to-do, mark completed and update HANDOFF. If there is a commitable diff: run /git-staging without asking for confirmation. NEVER /git-prod. Do NOT re-arm an internal Loop skill - the external runner starts the next agent. End the response with exactly one line: "LOOP_TICK_RESULT: continue" if implementable to-dos remain, or "LOOP_TICK_RESULT: stop - <reason>" (plan exhausted, external blocker, or human decision needed).';
@@ -61,9 +62,16 @@ export async function runPlanLoop(opts: RunPlanLoopOptions): Promise<number> {
   process.on("SIGINT", onSigInt);
 
   try {
+    // Fail soft: missing skin.json keeps plain console.log (no crash).
+    const skin = await loadCliRunPlanSkin(opts.root);
+    const banners = createSkinBannerPrinter(skin);
+
     console.log(`Active plan: ${path.basename(planPath)}`);
     console.log(`Pending to-dos: ${await pending()} | max ticks: ${opts.maxTicks}`);
     console.log(`Backend: ${opts.backend.id}`);
+    if (skin) {
+      console.log(`CLI skin: ${skin.displayName ?? skin.id}`);
+    }
 
     if (opts.dryRun) {
       console.log("--dry-run: no agent will be started. Tick prompt:");
@@ -84,12 +92,16 @@ export async function runPlanLoop(opts: RunPlanLoopOptions): Promise<number> {
     while (true) {
       tick += 1;
       if (tick > opts.maxTicks) {
-        console.log(`Budget of ${opts.maxTicks} ticks reached - stopping. Run again to continue.`);
+        const msg = `Budget of ${opts.maxTicks} ticks reached - stopping. Run again to continue.`;
+        if (banners) banners.stop(msg);
+        else console.log(msg);
         break;
       }
 
       if (await fileExists(stopFile)) {
-        console.log(`Stop file found (${stopFile}) - stopping.`);
+        const msg = `Stop file found (${stopFile}) - stopping.`;
+        if (banners) banners.stop(msg);
+        else console.log(msg);
         try {
           await rm(stopFile, { force: true });
         } catch {
@@ -108,7 +120,9 @@ export async function runPlanLoop(opts: RunPlanLoopOptions): Promise<number> {
       const logPath = path.join(logDir, `tick-${stamp()}.log`);
       const relLog = path.relative(opts.root, logPath);
       console.log("");
-      console.log(`=== tick ${tick}/${opts.maxTicks} - pending: ${before} - log: ${relLog} ===`);
+      const tickLine = `=== tick ${tick}/${opts.maxTicks} - pending: ${before} - log: ${relLog} ===`;
+      if (banners) banners.tickStart(tickLine);
+      else console.log(tickLine);
 
       let agentExit = 0;
       try {
@@ -127,9 +141,10 @@ export async function runPlanLoop(opts: RunPlanLoopOptions): Promise<number> {
       try {
         const logText = await readFile(logPath, "utf8");
         if (logText.includes("Too many MCP tools")) {
-          console.log(
-            "Too many MCP tools for the headless model - disable servers (cursor-agent mcp disable <id>) and run again.",
-          );
+          const msg =
+            "Too many MCP tools for the headless model - disable servers (cursor-agent mcp disable <id>) and run again.";
+          if (banners) banners.stop(msg);
+          else console.log(msg);
           break;
         }
       } catch {
@@ -137,14 +152,22 @@ export async function runPlanLoop(opts: RunPlanLoopOptions): Promise<number> {
       }
 
       if (agentExit !== 0) {
-        console.log(
-          `${opts.backend.id} exited with code ${agentExit} - stopping. See log: ${logPath}`,
-        );
+        const msg = `${opts.backend.id} exited with code ${agentExit} - stopping. See log: ${logPath}`;
+        if (banners) {
+          banners.tickEnd(`exit ${agentExit}`);
+          banners.stop(msg);
+        } else {
+          console.log(msg);
+        }
         break;
       }
 
       const sentinel = await parseSentinelFromLogFile(logPath);
       const after = await pending();
+
+      if (banners) {
+        banners.tickEnd(`pending: ${after}`);
+      }
 
       if (sentinel.kind === "continue") {
         // ok
@@ -160,9 +183,9 @@ export async function runPlanLoop(opts: RunPlanLoopOptions): Promise<number> {
           `warn: tick without sentinel, but progress (${before} -> ${after}) - continuing.`,
         );
       } else {
-        console.log(
-          `Tick without sentinel and no progress (${before} -> ${after}) - stopping for safety.`,
-        );
+        const msg = `Tick without sentinel and no progress (${before} -> ${after}) - stopping for safety.`;
+        if (banners) banners.stop(msg);
+        else console.log(msg);
         break;
       }
 
@@ -173,12 +196,15 @@ export async function runPlanLoop(opts: RunPlanLoopOptions): Promise<number> {
       }
 
       if (opts.sleepSeconds > 0) {
+        if (banners) banners.sleep(opts.sleepSeconds);
         await sleep(opts.sleepSeconds * 1000);
       }
     }
 
     const pendingNow = await pending();
     console.log("");
+    const finishDetail = `after ${tick} tick(s); pending: ${pendingNow}`;
+    if (banners) banners.phaseComplete(finishDetail);
     console.log(
       `Loop finished after ${tick} tick(s). Pending now: ${pendingNow}. Logs in ${path.relative(opts.root, logDir)}/`,
     );

--- a/packages/cli/src/plan-loop/skin-banners.test.ts
+++ b/packages/cli/src/plan-loop/skin-banners.test.ts
@@ -1,0 +1,93 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_CLI_SKIN_ID,
+  createSkinBannerPrinter,
+  loadCliRunPlanSkin,
+  loadSkinPack,
+  resolveCliSkinId,
+} from "./skin-banners.js";
+
+async function writeSkin(root: string, id: string, body: Record<string, unknown>): Promise<void> {
+  const dir = path.join(root, "registry", "skins", "core", id);
+  await mkdir(dir, { recursive: true });
+  await writeFile(path.join(dir, "skin.json"), `${JSON.stringify(body, null, 2)}\n`);
+}
+
+describe("skin-banners", () => {
+  const logs: string[] = [];
+  afterEach(() => {
+    logs.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  it("defaults cli skin id to ghost-runner when config missing", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "ak-skin-"));
+    expect(await resolveCliSkinId(root)).toBe(DEFAULT_CLI_SKIN_ID);
+  });
+
+  it("reads workspaceSkin.modes[cli-run-plan] from config", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "ak-skin-"));
+    const cfgDir = path.join(root, ".cursor", "context");
+    await mkdir(cfgDir, { recursive: true });
+    await writeFile(
+      path.join(cfgDir, "config.json"),
+      JSON.stringify({
+        workspaceSkin: { modes: { "cli-run-plan": "night-shift" } },
+      }),
+    );
+    expect(await resolveCliSkinId(root)).toBe("night-shift");
+  });
+
+  it("returns null when skin.json is missing (fail soft)", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "ak-skin-"));
+    expect(await loadSkinPack(root, "ghost-runner")).toBeNull();
+    expect(await loadCliRunPlanSkin(root)).toBeNull();
+  });
+
+  it("loads skin pack and prints tick banners via kolorist prefixes", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "ak-skin-"));
+    await writeSkin(root, "ghost-runner", {
+      id: "ghost-runner",
+      displayName: "Ghost Runner",
+      cliBanners: {
+        tickStart: "[GR] spectre online",
+        tickEnd: "[GR] spectre clear",
+        phaseComplete: "[GR] phase ghosted",
+      },
+      ansiPalette: { primary: "white", secondary: "gray", accent: "green" },
+    });
+
+    const pack = await loadCliRunPlanSkin(root);
+    expect(pack?.id).toBe("ghost-runner");
+
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    });
+
+    const banners = createSkinBannerPrinter(pack);
+    expect(banners).not.toBeNull();
+    if (!banners) {
+      throw new Error("expected skin banner printer");
+    }
+    banners.tickStart("=== tick 1/2 ===");
+    banners.tickEnd("pending: 1");
+    banners.sleep(5);
+    banners.phaseComplete("after 1 tick(s)");
+    banners.stop("budget reached");
+
+    expect(logs[0]).toContain("[GR] spectre online");
+    expect(logs[0]).toContain("=== tick 1/2 ===");
+    expect(logs[1]).toContain("[GR] spectre clear");
+    expect(logs[2]).toContain("sleep 5s");
+    expect(logs[3]).toContain("[GR] phase ghosted");
+    expect(logs[4]).toContain("budget reached");
+  });
+
+  it("createSkinBannerPrinter returns null without cliBanners", () => {
+    expect(createSkinBannerPrinter({ id: "x" })).toBeNull();
+    expect(createSkinBannerPrinter(null)).toBeNull();
+  });
+});

--- a/packages/cli/src/plan-loop/skin-banners.ts
+++ b/packages/cli/src/plan-loop/skin-banners.ts
@@ -1,0 +1,159 @@
+import path from "node:path";
+import {
+  blue,
+  cyan,
+  gray,
+  green,
+  lightGray,
+  lightGreen,
+  magenta,
+  red,
+  white,
+  yellow,
+} from "kolorist";
+import { readJson } from "../utils/fs.js";
+
+/** Config mode key for headless `agent-kit run-plan`. */
+export const CLI_RUN_PLAN_MODE = "cli-run-plan";
+
+/** Default skin when config omits `workspaceSkin.modes["cli-run-plan"]`. */
+export const DEFAULT_CLI_SKIN_ID = "ghost-runner";
+
+export interface SkinCliBanners {
+  tickStart?: string;
+  tickEnd?: string;
+  phaseComplete?: string;
+}
+
+export interface SkinPack {
+  id: string;
+  displayName?: string;
+  cliBanners?: SkinCliBanners;
+  ansiPalette?: {
+    primary?: string;
+    secondary?: string;
+    accent?: string;
+  };
+}
+
+type ColorFn = (s: string) => string;
+
+const COLORS: Record<string, ColorFn> = {
+  white,
+  gray,
+  green,
+  cyan,
+  magenta,
+  yellow,
+  red,
+  blue,
+  "light-green": lightGreen,
+  lightgreen: lightGreen,
+  "light-gray": lightGray,
+  lightgray: lightGray,
+};
+
+function resolveColor(name: string | undefined, fallback: ColorFn): ColorFn {
+  if (!name) return fallback;
+  return COLORS[name.toLowerCase()] ?? fallback;
+}
+
+interface WorkspaceSkinConfig {
+  workspaceSkin?: {
+    default?: string;
+    modes?: Record<string, string>;
+  };
+}
+
+/**
+ * Resolve CLI skin id from `.cursor/context/config.json`.
+ * Fail soft: missing/invalid config -> ghost-runner.
+ */
+export async function resolveCliSkinId(root: string): Promise<string> {
+  try {
+    const cfg = await readJson<WorkspaceSkinConfig>(
+      path.join(root, ".cursor", "context", "config.json"),
+    );
+    const id = cfg?.workspaceSkin?.modes?.[CLI_RUN_PLAN_MODE];
+    if (typeof id === "string" && id.trim()) return id.trim();
+  } catch {
+    // ignore parse/IO errors
+  }
+  return DEFAULT_CLI_SKIN_ID;
+}
+
+/**
+ * Load `registry/skins/core/<id>/skin.json` relative to project root.
+ * Fail soft: missing/invalid -> null (caller keeps plain console.log).
+ */
+export async function loadSkinPack(root: string, skinId: string): Promise<SkinPack | null> {
+  try {
+    const skinPath = path.join(root, "registry", "skins", "core", skinId, "skin.json");
+    const pack = await readJson<SkinPack>(skinPath);
+    if (!pack || typeof pack.id !== "string") return null;
+    return pack;
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve + load the active CLI run-plan skin, or null if unavailable. */
+export async function loadCliRunPlanSkin(root: string): Promise<SkinPack | null> {
+  const id = await resolveCliSkinId(root);
+  return loadSkinPack(root, id);
+}
+
+export interface SkinBannerPrinter {
+  /** Tick start: prefix from `cliBanners.tickStart` + detail line. */
+  tickStart(detail: string): void;
+  /** Tick end after agent returns. */
+  tickEnd(detail?: string): void;
+  /** Loop finished / phase ghosted. */
+  phaseComplete(detail?: string): void;
+  /** Optional quiet line before inter-tick sleep. */
+  sleep(seconds: number): void;
+  /** Optional chrome when the loop stops early. */
+  stop(reason: string): void;
+}
+
+/**
+ * Build banner printers from a loaded skin.
+ * Returns null when there is no usable `cliBanners` (plain logs).
+ */
+export function createSkinBannerPrinter(skin: SkinPack | null): SkinBannerPrinter | null {
+  if (!skin?.cliBanners) return null;
+  const banners = skin.cliBanners;
+  if (!banners.tickStart && !banners.tickEnd && !banners.phaseComplete) return null;
+
+  const primary = resolveColor(skin.ansiPalette?.primary, white);
+  const secondary = resolveColor(skin.ansiPalette?.secondary, gray);
+  const accent = resolveColor(skin.ansiPalette?.accent, green);
+
+  return {
+    tickStart(detail: string) {
+      if (banners.tickStart) {
+        console.log(`${accent(banners.tickStart)} ${primary(detail)}`);
+      } else {
+        console.log(primary(detail));
+      }
+    },
+    tickEnd(detail?: string) {
+      if (!banners.tickEnd) return;
+      const line = detail ? `${banners.tickEnd} ${detail}` : banners.tickEnd;
+      console.log(secondary(line));
+    },
+    phaseComplete(detail?: string) {
+      if (!banners.phaseComplete) return;
+      const line = detail ? `${banners.phaseComplete} ${detail}` : banners.phaseComplete;
+      console.log(accent(line));
+    },
+    sleep(seconds: number) {
+      console.log(secondary(`sleep ${seconds}s`));
+    },
+    stop(reason: string) {
+      if (banners.tickEnd) {
+        console.log(secondary(`${banners.tickEnd} ${reason}`));
+      }
+    },
+  };
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -77,6 +77,25 @@ export interface ScanResult {
   services: ServicesDetection;
 }
 
+/** Built-in workspace skin ids (`registry/skins/core/`). */
+export type WorkspaceSkinId = "autopilot" | "night-shift" | "ghost-runner";
+
+/** Mode → skin map persisted under `.cursor/context/config.json` → `workspaceSkin`. */
+export interface WorkspaceSkinConfig {
+  default: WorkspaceSkinId;
+  modes: {
+    "continue-plan": WorkspaceSkinId;
+    "run-plan": WorkspaceSkinId;
+    "cli-run-plan": WorkspaceSkinId;
+  };
+}
+
+/** Wizard choice: mode defaults, one skin for all modes, or skip writing. */
+export type WorkspaceSkinChoice =
+  | { kind: "mode-defaults" }
+  | { kind: "skin"; id: WorkspaceSkinId }
+  | { kind: "skip" };
+
 export interface ProjectProfile {
   rootDir: string;
   stack: StackDetection;
@@ -86,6 +105,8 @@ export interface ProjectProfile {
   services: ServicesDetection;
   installHooks: boolean;
   selectedCoreComponents: string[];
+  /** Optional: from init wizard; written to `.cursor/context/config.json` when not skip. */
+  workspaceSkinChoice?: WorkspaceSkinChoice;
 }
 
 /**

--- a/packages/cli/src/utils/prompts.ts
+++ b/packages/cli/src/utils/prompts.ts
@@ -6,7 +6,36 @@ import type {
   ProjectManagementTool,
   ProjectProfile,
   ScanResult,
+  WorkspaceSkinChoice,
+  WorkspaceSkinConfig,
+  WorkspaceSkinId,
 } from "../types.js";
+
+/** Mode defaults matching `.cursor/context/config.example.json`. */
+export const WORKSPACE_SKIN_MODE_DEFAULTS: WorkspaceSkinConfig = {
+  default: "autopilot",
+  modes: {
+    "continue-plan": "autopilot",
+    "run-plan": "night-shift",
+    "cli-run-plan": "ghost-runner",
+  },
+};
+
+export function workspaceSkinConfigFromChoice(
+  choice: WorkspaceSkinChoice,
+): WorkspaceSkinConfig | null {
+  if (choice.kind === "skip") return null;
+  if (choice.kind === "mode-defaults")
+    return { ...WORKSPACE_SKIN_MODE_DEFAULTS, modes: { ...WORKSPACE_SKIN_MODE_DEFAULTS.modes } };
+  return {
+    default: choice.id,
+    modes: {
+      "continue-plan": choice.id,
+      "run-plan": choice.id,
+      "cli-run-plan": choice.id,
+    },
+  };
+}
 
 function ensureNotCancelled<V>(value: V | symbol): V {
   if (isCancel(value)) {
@@ -87,6 +116,31 @@ async function askProjectManagement(
   ) as ProjectManagementTool[];
 }
 
+/** Optional workspace skin (mirrors `/onboard` Ask questions; clack only, not IDE AskQuestion). */
+async function askWorkspaceSkin(): Promise<WorkspaceSkinChoice> {
+  type SkinSelect = "mode-defaults" | WorkspaceSkinId | "skip";
+  const value = ensureNotCancelled(
+    await select<SkinSelect>({
+      message: "Workspace skin for chat/CLI chrome? (optional)",
+      initialValue: "mode-defaults",
+      options: [
+        {
+          label: "Keep mode defaults (Autopilot/Night Shift/Ghost Runner per mode)",
+          value: "mode-defaults",
+        },
+        { label: "Autopilot", value: "autopilot" },
+        { label: "Night Shift", value: "night-shift" },
+        { label: "Ghost Runner", value: "ghost-runner" },
+        { label: "Skip for now", value: "skip" },
+      ],
+    }),
+  );
+
+  if (value === "skip") return { kind: "skip" };
+  if (value === "mode-defaults") return { kind: "mode-defaults" };
+  return { kind: "skin", id: value };
+}
+
 export async function runExistingProjectWizard(scan: ScanResult): Promise<ProjectProfile> {
   const ide = await askIdeAndPlan(scan.ide);
   const workflow = await askGitWorkflow(scan.git.workflow);
@@ -97,6 +151,7 @@ export async function runExistingProjectWizard(scan: ScanResult): Promise<Projec
       initialValue: true,
     }),
   );
+  const workspaceSkinChoice = await askWorkspaceSkin();
 
   return {
     rootDir: scan.rootDir,
@@ -116,6 +171,7 @@ export async function runExistingProjectWizard(scan: ScanResult): Promise<Projec
       "docs-repo",
       "ide-guide",
     ],
+    workspaceSkinChoice,
   };
 }
 
@@ -179,6 +235,7 @@ export async function runGreenfieldWizard(scan: ScanResult): Promise<ProjectProf
       initialValue: true,
     }),
   );
+  const workspaceSkinChoice = await askWorkspaceSkin();
 
   return {
     rootDir: scan.rootDir,
@@ -206,5 +263,6 @@ export async function runGreenfieldWizard(scan: ScanResult): Promise<ProjectProf
       "docs-repo",
       "ide-guide",
     ],
+    workspaceSkinChoice,
   };
 }


### PR DESCRIPTION
## Summary

- Automated allowlist sync from the private source of truth.
- Release `v4.4.1`.
- Head branch `sync/v4.4.1-3fc3c15`.

## Release notes

### Fixed

- CLI: Biome lint/format on `skin-banners` unit test and related `init`/`prompts` format drift (non-null assertions blocked CI `build` after `v4.4.0`, which skipped `publish-npm` and `sync-public`)

## Source

- Commit: `3fc3c15`
- Head branch: `sync/v4.4.1-3fc3c15`