### PR TITLE
chore: sync private v4.4.3 (9b46012)

### DIFF
--- a/.cursor/hooks/agent/session-plan-guard.py
+++ b/.cursor/hooks/agent/session-plan-guard.py
@@ -27,6 +27,14 @@ FIRST_SESSION_NUDGE = """
 Agent Kit L0 is installed but onboarding has not run (`onboarded` marker missing). Offer or run `/onboard` before other work (welcome + Ask questions). Do not skip to coding. `/onboard` does not write plan files; plan bootstrap is `/start-project`.
 """.strip()
 
+DOGFOOD_INBOX_HINT = """
+## Dogfood inbox
+
+Unprocessed files are listed under `dogfood/README.md` (### Unprocessed Files). Follow the ingest ritual there (detect → analyze → memory WRITE → triage). Do not auto-start analysis unless the user asks.
+""".strip()
+
+_NONE_PLACEHOLDERS = frozenset({"none", "n/a", "empty", "nil"})
+
 
 def read_text(path: Path, limit: int = 60) -> str:
     try:
@@ -59,6 +67,46 @@ def is_onboarded(root: Path) -> bool:
     return data.get("onboarded") is True
 
 
+def parse_unprocessed_dogfood_items(readme_text: str) -> list[str]:
+    """File-like bullets from ### Unprocessed Files; empty when none / *None* only."""
+    items: list[str] = []
+    in_section = False
+    for line in readme_text.splitlines():
+        if line.startswith("### Unprocessed Files"):
+            in_section = True
+            continue
+        if not in_section:
+            continue
+        if line.startswith("### "):
+            break
+        stripped = line.strip()
+        if not stripped.startswith("- "):
+            continue
+        body = stripped[2:].strip()
+        normalized = body.lower().strip("*_ ")
+        if not normalized or normalized in _NONE_PLACEHOLDERS:
+            continue
+        items.append(body)
+    return items
+
+
+def dogfood_inbox_section(root: Path) -> str | None:
+    """Hint when dogfood/ exists and the index lists unprocessed file bullets."""
+    dogfood_dir = root / "dogfood"
+    if not dogfood_dir.is_dir():
+        return None
+    readme = dogfood_dir / "README.md"
+    if not readme.is_file():
+        return None
+    try:
+        text = readme.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    if not parse_unprocessed_dogfood_items(text):
+        return None
+    return DOGFOOD_INBOX_HINT
+
+
 def main() -> None:
     raw = sys.stdin.read()
     try:
@@ -74,6 +122,10 @@ def main() -> None:
 
     if l0_present(root) and not is_onboarded(root):
         parts.append(FIRST_SESSION_NUDGE)
+
+    dogfood_hint = dogfood_inbox_section(root)
+    if dogfood_hint:
+        parts.append(dogfood_hint)
 
     if handoff:
         parts.append("## Current HANDOFF.md (excerpt)\n\n" + handoff)

--- a/.cursor/hooks/agent/test_session_plan_guard.py
+++ b/.cursor/hooks/agent/test_session_plan_guard.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Stdlib unit checks for dogfood inbox parsing in session-plan-guard."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def _load_guard():
+    path = Path(__file__).with_name("session-plan-guard.py")
+    spec = importlib.util.spec_from_file_location("session_plan_guard", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+guard = _load_guard()
+parse_unprocessed_dogfood_items = guard.parse_unprocessed_dogfood_items
+dogfood_inbox_section = guard.dogfood_inbox_section
+DOGFOOD_INBOX_HINT = guard.DOGFOOD_INBOX_HINT
+
+
+class ParseUnprocessedDogfoodItemsTests(unittest.TestCase):
+    def test_none_placeholder_yields_empty(self) -> None:
+        text = """
+### Unprocessed Files
+
+*None*
+
+### Processed Files
+
+- `done.md`
+"""
+        self.assertEqual(parse_unprocessed_dogfood_items(text), [])
+
+    def test_file_bullets_collected(self) -> None:
+        text = """
+### Unprocessed Files
+
+- `cursor_a.md` - notes
+- `cursor_b.md`
+
+### Processed Files
+
+- `old.md`
+"""
+        self.assertEqual(
+            parse_unprocessed_dogfood_items(text),
+            ["`cursor_a.md` - notes", "`cursor_b.md`"],
+        )
+
+    def test_dash_none_bullet_skipped(self) -> None:
+        text = """
+### Unprocessed Files
+
+- *None*
+"""
+        self.assertEqual(parse_unprocessed_dogfood_items(text), [])
+
+    def test_missing_section_yields_empty(self) -> None:
+        self.assertEqual(parse_unprocessed_dogfood_items("# No section\n"), [])
+
+
+class DogfoodInboxSectionTests(unittest.TestCase):
+    def test_no_dogfood_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(dogfood_inbox_section(Path(tmp)))
+
+    def test_unprocessed_emits_hint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dogfood = root / "dogfood"
+            dogfood.mkdir()
+            (dogfood / "README.md").write_text(
+                "### Unprocessed Files\n\n- `new.md`\n\n### Processed Files\n\n*None*\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(dogfood_inbox_section(root), DOGFOOD_INBOX_HINT)
+
+    def test_empty_index_no_hint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            dogfood = root / "dogfood"
+            dogfood.mkdir()
+            (dogfood / "README.md").write_text(
+                "### Unprocessed Files\n\n*None*\n\n### Processed Files\n\n- `x.md`\n",
+                encoding="utf-8",
+            )
+            self.assertIsNone(dogfood_inbox_section(root))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 
 ## [Unreleased]
 
+## [4.4.3] - 2026-07-22
+
+### Docs
+
+- README: Features table covering plans/HITL, handoff, run modes, git spine, memory loop, workspace skins, external plan review, packs, and output hygiene; Docs table links skins + external plan review
+- Getting started: workspace skins subsection and onboard/continue-plan/run-plan skin defaults
+
+### Fixed
+
+- CLI: `resolve.test.ts` execFile mock callback arity (offline path) so `tsc --noEmit` passes in CI after 4.4.2
+
+## [4.4.2] - 2026-07-22
+
+### Added
+
+- Hooks: `sessionStart` (`session-plan-guard.py`) tips when `dogfood/README.md` lists unprocessed inbox files (no watchers; consumers without `dogfood/` unchanged)
+- Dogfood: private analysis surface with inbox contract (naming, index, ingest ritual); sessionStart surfaces unprocessed index entries
+
+### Fixed
+
+- CLI: auto-refresh remote registry cache on every resolve that reuses `~/.cache/agent-kit/registry/*` so new L0 artifacts (e.g. `onboard.md`) appear without requiring `--refresh`; offline/fetch failures still keep the existing cache
+
+### Docs
+
+- Update repository boundaries to document dogfood/ as private analysis folder
+- Document stale remote cache missing L0 onboard error in .cursor/memory/errors/
+
 ## [4.4.1] - 2026-07-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ Long AI coding sessions fall apart when the context window fills up. Agent Kit f
 - **Production needs confirmation.** Agent can push to staging alone; promoting to `main` always asks first.
 - **Clean history everywhere.** Commits and docs describe the software, not chat chatter.
 
+## Features
+
+| Feature | What you get |
+|---------|----------------|
+| **Plans + HITL gates** | `/start-project` Broad Intake, then two gates (write plan, then first unit). Confirmations use Ask questions (clickable options; chat fallback when the tool is unavailable). |
+| **Phase handoff** | `.cursor/HANDOFF.md` plus Context Guardian and native hooks (`sessionStart` / `preCompact`) so a fresh chat resumes without re-briefing. |
+| **Manual or continuous run** | `/continue-plan` (one phase per chat) or `/run-plan` (runs to the end; picks worker orchestration or in-session loop; headless via `agent-kit run-plan`). |
+| **Staging → prod git** | `/git-staging` for automatic promote to `origin/staging`; `/git-prod` only after explicit confirmation. Direct commits to `main` are blocked. |
+| **Memory loop** | Resolved errors and tradeoff decisions in `.cursor/memory/` so the next chat can reuse them. |
+| **Workspace skins** | Mode-aware chat/CLI chrome only: Autopilot (`/continue-plan`), Night Shift (`/run-plan`), Ghost Runner (CLI). Pick in `/onboard` or set `workspaceSkin` in `.cursor/context/config.json`. Never changes commits, HANDOFF, memory, or product docs. |
+| **Optional external plan review** | After a plan is exhausted, arm Claude Code for a gap monitor; triage with `/plan-review-triage`. Opt-in via config. |
+| **Skills + domain packs** | Registry skills and optional L1 packs (clean code, context tools, and more). Install/update via CLI; contribute upstream with `agent-kit contribute`. |
+| **Output hygiene** | Chat can be light; commits, docs, HANDOFF, and memory stay professional and inheritable. |
+
+Deep dives: [getting started](docs/getting-started.md), [skins contract](docs/skins-contract.md), [creating skins](docs/creating-skins.md), [external plan review](docs/external-plan-review.md), [domain packs](docs/domain-packs.md).
+
 ## Install
 
 ### In Cursor (recommended)
@@ -38,16 +54,16 @@ That's it. You now have a handful of slash commands and a small set of rules. Fu
 
 ## Usage
 
-1. **First-time setup:** `/onboard` - welcome with clickable options via Ask questions tool; sets onboarded marker (then `/start-project` when you have a goal).
+1. **First-time setup:** `/onboard` - welcome, optional workspace skin pick, and clickable options via Ask questions; sets onboarded marker (then `/start-project` when you have a goal).
 2. **Start a plan:** `/start-project` - Broad Intake Review, then two gates with Ask questions: (A) write plan file, (B) run first unit only after explicit confirmation.
 3. **Work one phase:** agent implements the current phase, updates handoff, and stops.
-4. **Continue later:** `/continue-plan` in a fresh chat picks up where you left off.
+4. **Continue later:** `/continue-plan` in a fresh chat picks up where you left off (Autopilot chat chrome by default).
 5. **Ship to staging:** `/git-staging` - branches, commits, merges automatically.
 
 Two ways to drive a plan:
 
 - **`/continue-plan`** - you drive: one phase per chat, the agent stops and waits between units.
-- **`/run-plan`** - it drives: the agent works through the plan to the end, checking off to-dos and pushing each finished topic to staging. It picks the best execution strategy itself (worker delegation when available, same-chat loop otherwise). Optional external plan review via Claude Code provides post-completion gap detection.
+- **`/run-plan`** - it drives: the agent works through the plan to the end, checking off to-dos and pushing each finished topic to staging (Night Shift chat chrome by default). It picks the best execution strategy itself (worker delegation when available, same-chat loop otherwise). Optional external plan review via Claude Code provides post-completion gap detection. Headless CLI ticks use Ghost Runner banners by default.
 
 **Production safety:** `/git-prod` promotes staging to `main` but always asks for confirmation first. Direct commits to `main` are blocked.
 
@@ -61,6 +77,8 @@ Full routine: `autogit/gitupdate.md` after install.
 | [Bootstrap](docs/bootstrap.md) | Exactly what lands in your project, and why there's no nested folder |
 | [Layers](docs/layers-spec.md) | How the base install, optional packs, and your local files layer together |
 | [Domain packs](docs/domain-packs.md) | Optional bundles: clean code, DevOps, testing, and more |
+| [Workspace skins](docs/skins-contract.md) | Mode defaults, `workspaceSkin` config, hygiene boundary ([create / contribute](docs/creating-skins.md)) |
+| [External plan review](docs/external-plan-review.md) | Opt-in Claude Code monitor after `/run-plan` exhaustion |
 | [Manifest](docs/agent-kit-manifest.md) | The `.cursor/agent-kit.json` file |
 | [Contributing](docs/CONTRIBUTING.md) | Working on the kit itself (includes contributor quickstart) |
 | [Docs index](docs/README.md) | Everything else |

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,8 @@ Agent Kit is a HITL framework for AI-assisted IDEs: plan, handoff, staging-to-pr
 - [Review layers](review-camadas.md) - final HITL / go-no-go pass
 - [Creating Skills](creating-skills.md) - skill format, placement, registry
 - [Creating Skins](creating-skins.md) - skin pack format, placement, contribute checklist
-- [Workspace skins contract](skins-contract.md) - skin pack schema, mode defaults, acceptance rules
+- [Workspace skins contract](skins-contract.md) - skin pack schema, mode defaults, acceptance rules (also summarized in the root [README Features](../README.md#features))
+- [External plan review](external-plan-review.md) - opt-in Claude Code monitor after plan exhaustion
 - [Cursor 3.0 Features](cursor-3-features.md) - how Agent Kit uses native IDE features
 - [Cursor-native audit](cursor-native-audit.md) - hooks.json, plugin, rule modes, VS Code/Windsurf gaps
 - [Coherence inventory](coherence-inventory.md) - classification of rules, skills, hooks, agents, commands

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,15 +48,19 @@ npx @dadado/agent-kit-cli init
 
 The idea is simple: work against a plan, save your place before a conversation gets too big, and (in manual mode) keep **one phase per chat**.
 
-0. **`/onboard`** *(first time only)* - Welcome and introduction to core commands via **Ask questions** tool (clickable options); sets onboarded marker. Path after CLI install: open the folder in Cursor → `/onboard` → `/start-project`.
+0. **`/onboard`** *(first time only)* - Welcome, optional **workspace skin** pick, and introduction to core commands via **Ask questions** tool (clickable options); sets onboarded marker and may write `workspaceSkin` into `.cursor/context/config.json`. Path after CLI install: open the folder in Cursor → `/onboard` → `/start-project`.
 1. **`/start-project`** - Broad Intake Review, then two gates using **Ask questions**: (A) the agent proposes and writes a plan with checkable to-dos (no coding yet); (B) only after you confirm, it runs the **first** unit. Uses clickable options with chat fallback when tool unavailable. Goal text in the same message is not execute permission.
 2. **Work one phase.** The agent implements the current phase (or one heavy to-do), checks it off, updates `.cursor/HANDOFF.md`, and stops. Context Guardian plus **native Cursor hooks** (`sessionStart` / `preCompact`) enforce that boundary; multi-phase in one window needs an explicit mode below.
 3. **`/handoff`** - when the chat is getting long (or the IDE is about to compact context), the agent writes down where things stand (and suggests pushing to staging if there's something worth committing).
-4. **New chat → `/continue-plan`** - it reads the handoff and continues, without you re-explaining the project.
+4. **New chat → `/continue-plan`** - it reads the handoff and continues, without you re-explaining the project. Chat tone follows the Autopilot skin by default (see [skins contract](skins-contract.md)).
+
+### Workspace skins
+
+Skins change **chat tone and CLI tick banners only**. Defaults by mode: Autopilot for `/continue-plan`, Night Shift for `/run-plan`, Ghost Runner for `agent-kit run-plan`. They never alter commits, HANDOFF, memory, or product documentation. Pick during `/onboard` / `agent-kit init`, change later via the onboarded menu, or edit `workspaceSkin` in `.cursor/context/config.json`. Contract and contribute path: [skins-contract.md](skins-contract.md), [creating-skins.md](creating-skins.md).
 
 ### Less babysitting
 
-- **`/run-plan`** - the agent works through the plan to the end, checking off to-dos and pushing to staging when there's something to commit. It picks the best execution strategy itself: worker delegation when your setup supports it (keeps the main chat from filling up), a same-chat loop otherwise. It never promotes to production on its own. The old `/run-plan-loop` and `/run-plan-orchestrated` still work as deprecated aliases.
+- **`/run-plan`** - the agent works through the plan to the end, checking off to-dos and pushing to staging when there's something to commit (Night Shift chat chrome by default). It picks the best execution strategy itself: worker delegation when your setup supports it (keeps the main chat from filling up), a same-chat loop otherwise. It never promotes to production on its own. The old `/run-plan-loop` and `/run-plan-orchestrated` still work as deprecated aliases.
 
 > **Note for headless/scheduled execution:** If running continuous plan loops or scheduled agents outside the IDE (e.g. via `agent-kit run-plan` or `scripts/plan-loop.sh`), use a separate git worktree or clone rather than sharing an interactive working tree. This prevents conflicts between automated commits and manual work.
 

--- a/docs/repository-boundaries.md
+++ b/docs/repository-boundaries.md
@@ -11,7 +11,7 @@ Mental shorthand: **local = scratch · private = factory · public = storefront 
 | Layer | What lives here | Git? | Sync to public? |
 |-------|-----------------|------|-----------------|
 | **Local scratch** | `HANDOFF.md`, `.cursor/plans/**/*.plan.md`, active context packs, `.env`, `.cursor/mcp.json`, personal notes | gitignored / never tracked | **Never** (gitignore + CI guard + sync prohibit) |
-| **Private repo** (`origin` → `agent-kit-dev`) | CLI, sync tooling, docs, Phase A `registry/**`, dogfood `.cursor/memory/` | staging → prod | Only **allowlist** paths in `scripts/public-sync.manifest` |
+| **Private repo** (`origin` → `agent-kit-dev`) | CLI, sync tooling, docs, Phase A `registry/**`, dogfood `.cursor/memory/`, `dogfood/` analysis | staging → prod | Only **allowlist** paths in `scripts/public-sync.manifest` |
 | **Public repo** (`public` / community → `agent-kit`) | Product surface: registry (SoT after Phase B), docs consumers need, L0 samples, LICENSE/README | PRs → `main` | N/A (destination) |
 
 ```text

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-kit",
-  "version": "4.4.1",
+  "version": "4.4.3",
   "description": "HITL framework for AI-assisted IDEs: plan, handoff, staging-to-prod, memory loop; project-aware setup for Cursor, VS Code, and Windsurf.",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dadado/agent-kit-cli",
-  "version": "4.4.1",
+  "version": "4.4.3",
   "description": "Agent Kit CLI: HITL framework install and tooling for AI-assisted IDEs (rules, skills, plan/handoff, context).",
   "type": "module",
   "bin": {

--- a/packages/cli/src/registry/resolve.test.ts
+++ b/packages/cli/src/registry/resolve.test.ts
@@ -1,5 +1,36 @@
-import { describe, expect, it } from "vitest";
-import { DEFAULT_REGISTRY_REF, DEFAULT_REGISTRY_URL, assertSafeRegistrySource } from "./resolve.js";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_REGISTRY_REF,
+  DEFAULT_REGISTRY_URL,
+  assertSafeRegistrySource,
+  resolveRegistryRoot,
+} from "./resolve.js";
+
+const homedirMock = vi.hoisted(() => vi.fn(() => tmpdir()));
+const execFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:os", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("node:os")>();
+  return { ...mod, homedir: () => homedirMock() };
+});
+
+vi.mock("node:child_process", () => ({
+  execFile: (...args: unknown[]) => execFileMock(...args),
+}));
+
+type ExecCb = (err: Error | null, stdout: string, stderr: string) => void;
+
+function execCallback(args: unknown[]): ExecCb | undefined {
+  const last = args[args.length - 1];
+  return typeof last === "function" ? (last as ExecCb) : undefined;
+}
+
+function gitArgs(args: unknown[]): string[] {
+  return Array.isArray(args[1]) ? (args[1] as string[]) : [];
+}
 
 describe("assertSafeRegistrySource", () => {
   it("accepts the default public registry", () => {
@@ -35,5 +66,106 @@ describe("assertSafeRegistrySource", () => {
     expect(() => assertSafeRegistrySource("https://github.com/org/repo", "main; rm -rf")).toThrow(
       /invalid/,
     );
+  });
+});
+
+describe("resolveRegistryRoot remote-cache", () => {
+  let cacheHome: string;
+  let projectCwd: string;
+
+  beforeEach(async () => {
+    cacheHome = await mkdtemp(path.join(tmpdir(), "agent-kit-cache-home-"));
+    projectCwd = await mkdtemp(path.join(tmpdir(), "agent-kit-project-"));
+    homedirMock.mockReturnValue(cacheHome);
+    execFileMock.mockReset();
+    execFileMock.mockImplementation((...args: unknown[]) => {
+      const cb = execCallback(args);
+      queueMicrotask(() => cb?.(null, "", ""));
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function seedRemoteCache(contents = '{"stale":true}\n'): Promise<string> {
+    // Mirror cacheKey(url, ref) layout under mocked homedir.
+    const { createHash } = await import("node:crypto");
+    const key = createHash("sha256")
+      .update(`${DEFAULT_REGISTRY_URL}@${DEFAULT_REGISTRY_REF}`)
+      .digest("hex")
+      .slice(0, 16);
+    const dest = path.join(cacheHome, ".cache", "agent-kit", "registry", key);
+    await mkdir(path.join(dest, "registry"), { recursive: true });
+    await writeFile(path.join(dest, "registry", "registry.json"), contents, "utf8");
+    return dest;
+  }
+
+  it("refreshes an existing remote-cache even without refresh:true", async () => {
+    const dest = await seedRemoteCache();
+
+    const resolved = await resolveRegistryRoot({ cwd: projectCwd });
+
+    expect(resolved.source).toBe("remote-cache");
+    expect(resolved.root).toBe(dest);
+    expect(execFileMock).toHaveBeenCalledWith(
+      "git",
+      ["fetch", "--depth", "1", "origin"],
+      expect.objectContaining({ cwd: dest }),
+      expect.any(Function),
+    );
+    expect(execFileMock).toHaveBeenCalledWith(
+      "git",
+      ["reset", "--hard", "FETCH_HEAD"],
+      expect.objectContaining({ cwd: dest }),
+      expect.any(Function),
+    );
+  });
+
+  it("keeps the existing cache when refresh fetch fails", async () => {
+    const stale = '{"stale":true,"keep":1}\n';
+    const dest = await seedRemoteCache(stale);
+
+    execFileMock.mockImplementation((...args: unknown[]) => {
+      const cb = execCallback(args);
+      const argv = gitArgs(args);
+      if (argv[0] === "fetch") {
+        queueMicrotask(() => cb?.(new Error("offline"), "", ""));
+        return;
+      }
+      queueMicrotask(() => cb?.(null, "", ""));
+    });
+
+    const resolved = await resolveRegistryRoot({ cwd: projectCwd, refresh: true });
+
+    expect(resolved.root).toBe(dest);
+    expect(await readFile(path.join(dest, "registry", "registry.json"), "utf8")).toBe(stale);
+  });
+
+  it("clones when remote-cache is missing (no fetch)", async () => {
+    execFileMock.mockImplementation((...args: unknown[]) => {
+      const cb = execCallback(args);
+      const argv = gitArgs(args);
+      queueMicrotask(async () => {
+        if (argv[0] === "clone") {
+          const dest = argv[argv.length - 1] as string;
+          await mkdir(path.join(dest, "registry"), { recursive: true });
+          await writeFile(path.join(dest, "registry", "registry.json"), '{"fresh":true}\n', "utf8");
+        }
+        cb?.(null, "", "");
+      });
+    });
+
+    const resolved = await resolveRegistryRoot({ cwd: projectCwd });
+
+    expect(resolved.source).toBe("remote-cache");
+    expect(execFileMock).toHaveBeenCalledWith(
+      "git",
+      expect.arrayContaining(["clone", "--depth", "1"]),
+      expect.any(Object),
+      expect.any(Function),
+    );
+    const fetchCalls = execFileMock.mock.calls.filter((call) => gitArgs(call)[0] === "fetch");
+    expect(fetchCalls).toHaveLength(0);
   });
 });

--- a/packages/cli/src/registry/resolve.ts
+++ b/packages/cli/src/registry/resolve.ts
@@ -121,7 +121,9 @@ export async function resolveRegistryRoot(options: {
   const dest = path.join(homedir(), ".cache", "agent-kit", "registry", cacheKey(url, ref));
 
   if (await hasRegistryIndex(dest)) {
-    if (options.refresh) await refreshCache(dest);
+    // Always refresh so L0 artifacts added after the first clone are visible.
+    // options.refresh / --refresh remains accepted for CLI/docs compatibility (same path).
+    await refreshCache(dest);
     return { root: dest, source: "remote-cache", url, ref };
   }
 


### PR DESCRIPTION
## Summary

- Automated allowlist sync from the private source of truth.
- Release `v4.4.3`.
- Head branch `sync/v4.4.3-9b46012`.

## Release notes

### Docs

- README: Features table covering plans/HITL, handoff, run modes, git spine, memory loop, workspace skins, external plan review, packs, and output hygiene; Docs table links skins + external plan review
- Getting started: workspace skins subsection and onboard/continue-plan/run-plan skin defaults

### Fixed

- CLI: `resolve.test.ts` execFile mock callback arity (offline path) so `tsc --noEmit` passes in CI after 4.4.2

## Source

- Commit: `9b46012`
- Head branch: `sync/v4.4.3-9b46012`