### PR TITLE
chore: sync private v4.4.5 (454e263)

### DIFF
--- a/.cursor/commands/git-prod.md
+++ b/.cursor/commands/git-prod.md
@@ -15,3 +15,4 @@ Follow the **git prod** routine to promote `origin/staging` to `origin/main` (pr
 5. Run merge to main, push main, create/push annotated vX.Y.Z tag (when absent), confirm production.
 6. Update `.cursor/HANDOFF.md` ("promoted to production") and memory-loop WRITE if it applies.
 7. In this monorepo: annotated tags trigger `publish-npm` + `sync-public` CI; `pnpm git:trigger-public-sync` fallback when needed per `autogit/gitupdate.md`.
+8. **Post-prod verification (mandatory in this monorepo):** before ending, check tag CI jobs (`publish-npm`, `sync-public`), `npm view @dadado/agent-kit-cli version`, public `main` sync commit, and public GitHub Release Latest. Report each row. Silent npm success with a stale public Releases badge is a kit failure mode — see `autogit/gitupdate.md` step 12.5.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Guard public tree (no tracked local-only Cursor paths)
         run: |
@@ -30,10 +30,10 @@ jobs:
           fi
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm
@@ -68,14 +68,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
+      # setup-node@v5 enables package-manager-cache by default when package.json
+      # has "packageManager". This job only runs node (no pnpm install), so disable
+      # the cache and install pnpm first so the resolver does not fail the job.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
+          package-manager-cache: false
 
       - name: Run sync
         run: |
@@ -92,6 +99,8 @@ jobs:
           PUBLIC_BRANCH: main
           # Default: auto-merge after create/update. Set repo/org var to "false" to opt out.
           PUBLIC_SYNC_AUTO_MERGE: ${{ vars.PUBLIC_SYNC_AUTO_MERGE || 'true' }}
+          # After the sync PR merges, create/update the public GitHub Release for this version.
+          PUBLIC_SYNC_CREATE_RELEASE: ${{ vars.PUBLIC_SYNC_CREATE_RELEASE || 'true' }}
           GIT_AUTHOR_NAME: agent-kit-sync
           GIT_AUTHOR_EMAIL: sync@agent-kit.dev
 
@@ -107,13 +116,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: pnpm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 
 ## [Unreleased]
 
+## [4.4.5] - 2026-07-22
+
+### Fixed
+
+- CI: `sync-public` job installs pnpm and disables `setup-node` package-manager-cache so tag pushes after Actions v5 do not fail with `Unable to locate executable file: pnpm`
+
+### Added
+
+- Sync: after the public sync PR merges, create a public GitHub Release (`vX.Y.Z`) from CHANGELOG notes so the storefront Latest badge tracks the release (opt out with `PUBLIC_SYNC_CREATE_RELEASE=false`)
+
+## [4.4.4] - 2026-07-22
+
+### Changed
+
+- CI: bump GitHub Actions to Node 24 runtimes (`actions/checkout@v5`, `actions/setup-node@v5`, `pnpm/action-setup@v5`) to clear Node 20 deprecation annotations; job toolchain stays on Node 20
+
 ## [4.4.3] - 2026-07-22
 
 ### Docs

--- a/autogit/gitupdate.md
+++ b/autogit/gitupdate.md
@@ -403,9 +403,22 @@ This section contains the detailed prompts that should be followed when commands
    - **Fallback**: If tag was not created or manual dispatch needed, run **`pnpm git:trigger-public-sync`** (or `bash scripts/trigger-public-sync-after-prod.sh`) to trigger CI workflow with public repository sync. See `docs/repository-boundaries.md`.
    - In projects without public mirror, skip this step.
 
+#### 12.5. **Post-prod verification (this monorepo — do not skip)**  
+   Tag push alone is not proof that consumers see the release. Before closing the chat, verify and report:
+
+   | Check | How |
+   |-------|-----|
+   | Private tag CI | `gh run list` for the `vX.Y.Z` tag: `build`, `publish-npm`, and `sync-public` all green |
+   | npm | `npm view @dadado/agent-kit-cli version` matches the release |
+   | Public `main` | Latest commit message like `chore: sync private vX.Y.Z (...)` |
+   | Public GitHub Release | `gh release list -R <public>` shows `vX.Y.Z` as Latest (not a stale older release) |
+
+   If `sync-public` failed or the public Release is missing: fix or re-run (`pnpm git:trigger-public-sync`), do not assume success from a green local merge/push. Write a memory/dogfood note when the gap was silent (npm green, public storefront stale).
+
 #### 13. **Final Report**  
    - Summarize executed actions, list commits promoted to production, inform merge status, mention if CHANGELOG.md was updated and any necessary follow-ups.
    - **Highlight**: Clearly inform that changes are now in production (`origin/main`).
+   - Include the step 12.5 verification results (pass/fail per row).
    - Update `.cursor/HANDOFF.md` ("promoted to production"); if appropriate, memory-loop WRITE.
 
 ---

--- a/docs/repository-boundaries.md
+++ b/docs/repository-boundaries.md
@@ -41,7 +41,8 @@ Do not `git add -f` session paths. Contributions after Phase B: registry PRs go 
 3. **Automatic triggers** - Annotated `v*` tags trigger both `publish-npm` (when `NPM_TOKEN` configured) and `sync-public` (when `PUBLIC_REPO_TOKEN` configured) CI jobs.
 4. **Public sync PR** - Creates semantic PR body (Summary + CHANGELOG release notes + source SHA) against public `main`.
 5. **Auto-merge** - PRs auto-merge after required checks pass (`gh pr merge --auto`). Set `PUBLIC_SYNC_AUTO_MERGE=false` to require manual merge.
-6. **Fallback** (manual dispatch): `pnpm git:trigger-public-sync` or *workflow_dispatch* in Actions when tag-based trigger is insufficient.
+6. **Public GitHub Release** - After the sync PR merges, sync creates/updates a public GitHub Release `vX.Y.Z` (CHANGELOG notes; Latest badge). Opt out with `PUBLIC_SYNC_CREATE_RELEASE=false`. Git tags alone do not move the Releases sidebar.
+7. **Fallback** (manual dispatch): `pnpm git:trigger-public-sync` or *workflow_dispatch* in Actions when tag-based trigger is insufficient.
 
 Without `PUBLIC_REPO_TOKEN` configured on the **private** GitHub repo, the sync job pushes nothing; the rest of CI still runs normally.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-kit",
-  "version": "4.4.3",
+  "version": "4.4.5",
   "description": "HITL framework for AI-assisted IDEs: plan, handoff, staging-to-prod, memory loop; project-aware setup for Cursor, VS Code, and Windsurf.",
   "private": true,
   "license": "MIT",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dadado/agent-kit-cli",
-  "version": "4.4.3",
+  "version": "4.4.5",
   "description": "Agent Kit CLI: HITL framework install and tooling for AI-assisted IDEs (rules, skills, plan/handoff, context).",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Automated allowlist sync from the private source of truth.
- Release `v4.4.5`.
- Head branch `sync/v4.4.5-454e263`.

## Release notes

### Fixed

- CI: `sync-public` job installs pnpm and disables `setup-node` package-manager-cache so tag pushes after Actions v5 do not fail with `Unable to locate executable file: pnpm`

### Added

- Sync: after the public sync PR merges, create a public GitHub Release (`vX.Y.Z`) from CHANGELOG notes so the storefront Latest badge tracks the release (opt out with `PUBLIC_SYNC_CREATE_RELEASE=false`)

## Source

- Commit: `454e263`
- Head branch: `sync/v4.4.5-454e263`