### PR TITLE
chore: sync private v4.5.0 (3e114d1)

### DIFF
--- a/packages/cli/src/lifecycle/l0.test.ts
+++ b/packages/cli/src/lifecycle/l0.test.ts
@@ -132,7 +132,9 @@ describe("canonical L0 inventory", () => {
     expectUnique(portBTargets, "Port B targets");
     expectUnique(portBPairs, "Port B mappings");
 
-    expect(sorted(registryL0Paths)).toEqual(sorted(canonicalSources));
+    // The registry may hold extra L0 entries (e.g. public-only skills).
+    // All canonical sources must still be present.
+    expect(registryL0Paths).toEqual(expect.arrayContaining(canonicalSources));
     expect(sorted(portBPairs)).toEqual(sorted(canonicalPairs));
     expect(canonicalTargets).toEqual(expect.arrayContaining(requiredRuleTargets));
     expect(canonicalTargets).toEqual(expect.arrayContaining(requiredTemplateTargets));

--- a/packages/cli/src/scanner/readiness-scenarios.test.ts
+++ b/packages/cli/src/scanner/readiness-scenarios.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { cp, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { access, cp, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -143,6 +143,13 @@ describe("readiness integration scenarios", () => {
   });
 
   it("dogfoods the ops/knowledge self-hosted fixture signals", async () => {
+    if (
+      !(await access(FIXTURE_ROOT)
+        .then(() => true)
+        .catch(() => false))
+    ) {
+      return; // dogfood fixture only in private repo
+    }
     const root = await mkdtemp(path.join(os.tmpdir(), "agent-kit-dogfood-ops-"));
     await cp(FIXTURE_ROOT, root, { recursive: true });
     await initializeGit(root);


### PR DESCRIPTION
## Summary

- Automated allowlist sync from the private source of truth.
- Release `v4.5.0`.
- Head branch `sync/v4.5.0-3e114d1`.

## Release notes

### Added

- Design contract and dogfood acceptance criteria for repository-readiness onboarding, including install-to-agent discovery handoff and the namespaced `/agent-kit-onboard` decision
- CLI readiness model, repository scanner, provider evidence, and portable snapshot contract for application and non-application repositories
- Idempotent safe-readiness fixes with dry-run evidence, merge-safe repository profiles, and versioned onboarding state
- Unified install, init, doctor, and status readiness workflow with canonical L0 inventory and version parity checks
- Namespaced `/agent-kit-onboard` readiness journey with managed legacy-command migration and resume-aware session guidance
- Evidence-based repository personalization with protected ownership metadata and prepared `/start-project` profile reuse
- Readiness integration scenarios, L0 inventory parity guards, prompts unit coverage, and ops/knowledge self-hosted dogfood fixture

### Changed

- Docs and installer brief: single readiness narrative around `/agent-kit-onboard`; skins and external review stay optional after essentials
- Legacy welcome-only `/onboard` completion semantics superseded by verified readiness (see memory decisions)
- Built-in workspace skins (Autopilot, Night Shift, Ghost Runner) now include thematic emojis in chat hints and CLI banners

## Source

- Commit: `3e114d1`
- Head branch: `sync/v4.5.0-3e114d1`