### PR TITLE
chore: sync private v4.6.0 (dd28911)

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -13,6 +13,6 @@
     "anti-slop"
   ],
   "license": "MIT",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "repository": "https://github.com/agent-kit-startup/agent-kit"
 }

--- a/.cursor/agent-kit.json
+++ b/.cursor/agent-kit.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "version": "4.5.0",
+  "version": "4.6.0",
   "protected": [
     ".cursor/HANDOFF.md",
     ".cursor/plans/**",

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 # User preferences config
 .cursor/context/config.json
 
+# Generated readiness snapshot and init/scan profile (local workspace state)
+.cursor/context/readiness.json
+.cursor/agent-kit.config.json
+
 # Active Context Packs (are local)
 .cursor/context/current/*.md
 !.cursor/context/current/.gitkeep
@@ -45,3 +49,7 @@ dist/
 coverage/
 .turbo/
 *.tsbuildinfo
+*.p12
+*.pfx
+*credentials*.json
+*service-account*.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 
 ---
 
+## [Unreleased]
+
+## [4.6.0] - 2026-07-24
+
+### Added
+
+- Local Agent Kit dashboard (`npm run start:dashboard`) with live activity indicators, SSE heartbeat, process/terminal diffing, and responsive/a11y polish
+
+### Fixed
+
+- CI and tests made portable to the public mirror (root-scoped plans guard, dogfood fixture skip, L0 registry assertions that tolerate public-owned `registry.json` drift)
+- Version manifests (`.cursor/agent-kit.json`, `.cursor-plugin/plugin.json`) kept in sync with package SemVer on release
+
+### Changed
+
+- `.gitignore`: ignore PKCS12/PFX and credential JSON patterns; ignore local readiness snapshot and `agent-kit.config.json`
+
 ## [4.5.0] - 2026-07-24
 
 ### Added
@@ -23,8 +40,6 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 - Docs and installer brief: single readiness narrative around `/agent-kit-onboard`; skins and external review stay optional after essentials
 - Legacy welcome-only `/onboard` completion semantics superseded by verified readiness (see memory decisions)
 - Built-in workspace skins (Autopilot, Night Shift, Ghost Runner) now include thematic emojis in chat hints and CLI banners
-
-## [Unreleased]
 
 ## [4.4.7] - 2026-07-23
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ Two ways to drive a plan:
 
 **Production safety:** `/git-prod` promotes staging to `main` but always asks for confirmation first. Direct commits to `main` are blocked.
 
+### Dashboard
+
+A live dashboard for the Agent Kit runtime state — plans, agents, git, terminals, processes, skills, health, activity. Open in Cursor Simple Browser:
+
+```bash
+npm run start:dashboard
+# or: node dashboard/serve.mjs
+```
+
+Then visit `http://localhost:3333` or open `dashboard/dashboard.html` in Simple Browser.
+
 Full routine: `autogit/gitupdate.md` after install.
 
 ## Docs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-kit",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "HITL framework for AI-assisted IDEs: plan, handoff, staging-to-prod, memory loop; project-aware setup for Cursor, VS Code, and Windsurf.",
   "private": true,
   "license": "MIT",
@@ -9,6 +9,7 @@
     "node": ">=20"
   },
   "scripts": {
+    "start:dashboard": "node dashboard/serve.mjs",
     "git:trigger-public-sync": "bash scripts/trigger-public-sync-after-prod.sh",
     "registry:build": "node scripts/build-registry.mjs",
     "build": "turbo run build",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dadado/agent-kit-cli",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "Agent Kit CLI: HITL framework install and tooling for AI-assisted IDEs (rules, skills, plan/handoff, context).",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Automated allowlist sync from the private source of truth.
- Release `v4.6.0`.
- Head branch `sync/v4.6.0-dd28911`.

## Release notes

### Added

- Local Agent Kit dashboard (`npm run start:dashboard`) with live activity indicators, SSE heartbeat, process/terminal diffing, and responsive/a11y polish

### Fixed

- CI and tests made portable to the public mirror (root-scoped plans guard, dogfood fixture skip, L0 registry assertions that tolerate public-owned `registry.json` drift)
- Version manifests (`.cursor/agent-kit.json`, `.cursor-plugin/plugin.json`) kept in sync with package SemVer on release

### Changed

- `.gitignore`: ignore PKCS12/PFX and credential JSON patterns; ignore local readiness snapshot and `agent-kit.config.json`

## Source

- Commit: `dd28911`
- Head branch: `sync/v4.6.0-dd28911`