### PR TITLE
chore: sync private v4.5.1 (ccd44f1)

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -13,6 +13,6 @@
     "anti-slop"
   ],
   "license": "MIT",
-  "version": "4.6.0",
+  "version": "4.5.1",
   "repository": "https://github.com/agent-kit-startup/agent-kit"
 }

--- a/.cursor/agent-kit.json
+++ b/.cursor/agent-kit.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "version": "4.6.0",
+  "version": "4.5.1",
   "protected": [
     ".cursor/HANDOFF.md",
     ".cursor/plans/**",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 
 ## [Unreleased]
 
-## [4.6.0] - 2026-07-24
-
-### Added
-
-- Local Agent Kit dashboard (`npm run start:dashboard`) with live activity indicators, SSE heartbeat, process/terminal diffing, and responsive/a11y polish
+## [4.5.1] - 2026-07-24
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -68,17 +68,6 @@ Two ways to drive a plan:
 
 **Production safety:** `/git-prod` promotes staging to `main` but always asks for confirmation first. Direct commits to `main` are blocked.
 
-### Dashboard
-
-A live dashboard for the Agent Kit runtime state — plans, agents, git, terminals, processes, skills, health, activity. Open in Cursor Simple Browser:
-
-```bash
-npm run start:dashboard
-# or: node dashboard/serve.mjs
-```
-
-Then visit `http://localhost:3333` or open `dashboard/dashboard.html` in Simple Browser.
-
 Full routine: `autogit/gitupdate.md` after install.
 
 ## Docs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-kit",
-  "version": "4.6.0",
+  "version": "4.5.1",
   "description": "HITL framework for AI-assisted IDEs: plan, handoff, staging-to-prod, memory loop; project-aware setup for Cursor, VS Code, and Windsurf.",
   "private": true,
   "license": "MIT",
@@ -9,7 +9,6 @@
     "node": ">=20"
   },
   "scripts": {
-    "start:dashboard": "node dashboard/serve.mjs",
     "git:trigger-public-sync": "bash scripts/trigger-public-sync-after-prod.sh",
     "registry:build": "node scripts/build-registry.mjs",
     "build": "turbo run build",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dadado/agent-kit-cli",
-  "version": "4.6.0",
+  "version": "4.5.1",
   "description": "Agent Kit CLI: HITL framework install and tooling for AI-assisted IDEs (rules, skills, plan/handoff, context).",
   "type": "module",
   "bin": {

--- a/scripts/build-registry.mjs
+++ b/scripts/build-registry.mjs
@@ -79,13 +79,13 @@ async function listPacks() {
 }
 
 /**
- * L0 artifacts are curated by hand (layers-spec), not derived from pack
- * manifests. Preserve them from the existing registry.json across rebuilds.
+ * Only L1 artifacts are derived from pack manifests. L0 and L2 are curated by
+ * hand (layers-spec), so they must survive a rebuild or they are silently lost.
  */
-async function readExistingL0Artifacts(outPath) {
+async function readCuratedArtifacts(outPath) {
   try {
     const existing = JSON.parse(await readFile(outPath, "utf8"));
-    return (existing.artifacts ?? []).filter((a) => a.layer === "L0");
+    return (existing.artifacts ?? []).filter((a) => a.layer !== "L1");
   } catch {
     return [];
   }
@@ -95,13 +95,13 @@ const core = await listSkillTier("core");
 const community = await listSkillTier("community");
 const { packs, artifacts } = await listPacks();
 const outPath = path.join(root, "registry", "registry.json");
-const l0Artifacts = await readExistingL0Artifacts(outPath);
+const curatedArtifacts = await readCuratedArtifacts(outPath);
 
 const index = {
   schemaVersion: 2,
   skills: { core, community },
   packs,
-  artifacts: [...l0Artifacts, ...artifacts],
+  artifacts: [...curatedArtifacts, ...artifacts],
 };
 
 const allIds = [...core, ...community].map((s) => s.id);


### PR DESCRIPTION
## Summary

- Automated allowlist sync from the private source of truth.
- Release `v4.5.1`.
- Head branch `sync/v4.5.1-ccd44f1`.

## Release notes

### Fixed

- CI and tests made portable to the public mirror (root-scoped plans guard, dogfood fixture skip, L0 registry assertions that tolerate public-owned `registry.json` drift)
- Version manifests (`.cursor/agent-kit.json`, `.cursor-plugin/plugin.json`) kept in sync with package SemVer on release

### Changed

- `.gitignore`: ignore PKCS12/PFX and credential JSON patterns; ignore local readiness snapshot and `agent-kit.config.json`

## Source

- Commit: `ccd44f1`
- Head branch: `sync/v4.5.1-ccd44f1`